### PR TITLE
feat: add an exposed endpoint to request a resource by resource id

### DIFF
--- a/src/clj/rems/api/catalogue.clj
+++ b/src/clj/rems/api/catalogue.clj
@@ -59,5 +59,5 @@
       :responses {200 {:schema schema/CatalogueItemFound}
                   404 {:schema s/Any :description "Not found"}}
       (if-let [it (first (catalogue/get-localized-catalogue-items {:resource resource}))]
-        (ok {:success true })
+        (ok {:success true})
         (not-found-json-response)))))

--- a/src/clj/rems/api/catalogue.clj
+++ b/src/clj/rems/api/catalogue.clj
@@ -56,8 +56,8 @@
     (GET "/:resource" []
       :summary "Get a specific catalogue of item"
       :path-params [resource :- (describe s/Str "resource id")]
-      :responses {200 {:schema schema/CatalogueItem}
+      :responses {200 {:schema schema/CatalogueItemFound}
                   404 {:schema s/Any :description "Not found"}}
       (if-let [it (first (catalogue/get-localized-catalogue-items {:resource resource}))]
-        (ok "{\"success\": \"" (:resource) "\"}")
+        (ok {:success true })
         (not-found-json-response)))))

--- a/src/clj/rems/api/catalogue.clj
+++ b/src/clj/rems/api/catalogue.clj
@@ -59,5 +59,5 @@
       :responses {200 {:schema schema/CatalogueItem}
                   404 {:schema s/Any :description "Not found"}}
       (if-let [it (first (catalogue/get-localized-catalogue-items {:resource resource}))]
-        (ok it)
+        (ok "{\"success\": \"" (:resource) "\"}")
         (not-found-json-response)))))

--- a/src/clj/rems/api/catalogue.clj
+++ b/src/clj/rems/api/catalogue.clj
@@ -2,7 +2,7 @@
   (:require [compojure.api.sweet :refer :all]
             [rems.api.schema :as schema]
             [rems.service.catalogue :as catalogue]
-            [rems.api.util] ; required for route :roles
+            [rems.api.util :refer [not-found-json-response]] ; required for route :roles
             [rems.auth.util :refer [throw-forbidden throw-unauthorized]]
             [rems.config :refer [env]]
             [rems.common.roles :as roles]
@@ -51,4 +51,13 @@
         (throw-unauthorized)
 
         :else
-        (throw-forbidden)))))
+        (throw-forbidden)))
+
+    (GET "/:resource" []
+      :summary "Get a specific catalogue of item"
+      :path-params [resource :- (describe s/Str "resource id")]
+      :responses {200 {:schema schema/CatalogueItem}
+                  404 {:schema s/Any :description "Not found"}}
+      (if-let [it (first (catalogue/get-localized-catalogue-items {:resource resource}))]
+        (ok it)
+        (not-found-json-response)))))

--- a/src/clj/rems/api/schema.clj
+++ b/src/clj/rems/api/schema.clj
@@ -307,3 +307,5 @@
 (s/defschema DeleteCategoryCommand
   schema-base/CategoryId)
 
+(s/defschema CatalogueItemFound
+  {:success s/Bool})


### PR DESCRIPTION
## Changes

**[New]** - No authentication request catalogue item by it's resource id

### URL

`/api/catalogue/{resource}`

### Responses

Example 200 Response
```json
{
        "archived": false,
        "localizations": {
            "en": {
                "id": 127,
                "langcode": "en",
                "title": "ANU Poll 2020: Bushfires, The Environment, and Optimism For The Future",
                "infourl": "https://dataverse-test.ada.edu.au/dataset.xhtml?persistentId=doi:10.80408/E7FERF"
            }
        },
        "resource-id": 127,
        "start": "2024-09-13T04:41:56.206Z",
        "organization": {
            "organization/id": "ADA",
            "organization/short-name": {
                "en": "ADA"
            },
            "organization/name": {
                "en": "Australian Data Archive"
            }
        },
        "wfid": 11,
        "resid": "doi:10.80408/E7FERF",
        "formid": 7,
        "categories": [],
        "id": 127,
        "expired": false,
        "end": null,
        "enabled": true
 }
```

Example 404 Response

```json
{
    "error": "not found"
}
```