### PR TITLE
506 forbidden comment attachments

### DIFF
--- a/src/clj/rems/service/attachment.clj
+++ b/src/clj/rems/service/attachment.clj
@@ -32,7 +32,7 @@
                                         (find-first #(= attachment-id (:attachment/id %))))
             redacted? (= :filename/redacted (:attachment/filename application-attachment))]
         (when (some #{:applicant :member :handler :decider} (:application/roles application)) (assoc-some attachment :attachment/filename (when redacted?
-                                                                                                      "redacted")))
+                                                                                                                                            "redacted")))
         (if (some? application-attachment) ; user can see the attachment
           (assoc-some attachment :attachment/filename (when redacted?
                                                         "redacted"))

--- a/src/clj/rems/service/attachment.clj
+++ b/src/clj/rems/service/attachment.clj
@@ -31,9 +31,7 @@
             application-attachment (->> (:application/attachments application)
                                         (find-first #(= attachment-id (:attachment/id %))))
             redacted? (= :filename/redacted (:attachment/filename application-attachment))]
-        (when (some #{:applicant :member :handler :decider} (:application/roles application)) (assoc-some attachment :attachment/filename (when redacted?
-                                                                                                                                            "redacted")))
-        (if (some? application-attachment) ; user can see the attachment
+        (if (some #{:applicant :member :handler :decider} (:application/roles application)) ; user can see all attachments if they are within the application
           (assoc-some attachment :attachment/filename (when redacted?
                                                         "redacted"))
           (throw-forbidden))))))

--- a/src/clj/rems/service/attachment.clj
+++ b/src/clj/rems/service/attachment.clj
@@ -31,6 +31,8 @@
             application-attachment (->> (:application/attachments application)
                                         (find-first #(= attachment-id (:attachment/id %))))
             redacted? (= :filename/redacted (:attachment/filename application-attachment))]
+        (when (some #{:applicant :member :handler :decider} (:application/roles application)) (assoc-some attachment :attachment/filename (when redacted?
+                                                                                                      "redacted")))
         (if (some? application-attachment) ; user can see the attachment
           (assoc-some attachment :attachment/filename (when redacted?
                                                         "redacted"))


### PR DESCRIPTION
### Changes

As the two way comments feature added the ability to upload an attachment without associating it directly with an application event, this meant that these two way comment attachments would never have correct permissions to view said attachments.

To remedy this, if a user is part of an application, they have the API permissions to view all attachments.

This is a hot-fix adjustment whilst two-way comments are added as a new event to the application.