### PR TITLE
519 Fixing Forbidden Attachments for Two-Way Comments

### DIFF
--- a/src/clj/rems/service/attachment.clj
+++ b/src/clj/rems/service/attachment.clj
@@ -7,6 +7,7 @@
             [rems.auth.util :refer [throw-forbidden]]
             [rems.db.applications :as applications]
             [rems.db.attachments :as attachments]
+            [rems.db.cadredb.comments :as comments]
             [rems.util :refer [getx]]
             [ring.util.http-response :refer [ok content-type header]])
   (:import [java.io ByteArrayInputStream ByteArrayOutputStream]
@@ -30,7 +31,8 @@
       (let [application (applications/get-application-for-user user-id (:application/id attachment))
             application-attachment (->> (:application/attachments application)
                                         (find-first #(= attachment-id (:attachment/id %))))
-            redacted? (= :filename/redacted (:attachment/filename application-attachment))]
+            redacted? (= :filename/redacted (:attachment/filename application-attachment))
+            comments (comments/get-app-comments (:application/id application) user-id)]
         (if (some? application-attachment) ; user can see the attachment
           (assoc-some attachment :attachment/filename (when redacted?
                                                         "redacted"))


### PR DESCRIPTION
### Description

Update the logic for the function `[src/clj/rems/service/attachment.clj] get-application-attachment` to include the following logic:

- **IF** attachment part of a two-way comment:
    - **IF** the two-way comment isn't address to anyone:
        - **[RETURN ATTACHMENT]**
        -  **ELSE**
            - **IF** current user is the person the comment is addressed to:
                - **[RETURN ATTACHMENT]**
                - **ELSE** **[FORBIDDEN]**
- **ELSE** follow old logic event attachment logic
