### PR TITLE
feat: return shortname

### DIFF
--- a/src/clj/rems/api/schema.clj
+++ b/src/clj/rems/api/schema.clj
@@ -96,7 +96,7 @@
 (s/defschema V2Resource
   {:resource/id s/Int
    :resource/ext-id s/Str
-   :resource/organization s/Str
+   :resource/organization schema-base/LocalizedString
    :catalogue-item/id s/Int
    :catalogue-item/categories [schema-base/Category]
    :catalogue-item/title schema-base/LocalizedString

--- a/src/clj/rems/application/cadre/model.clj
+++ b/src/clj/rems/application/cadre/model.clj
@@ -11,6 +11,7 @@
             [rems.permissions :as permissions]
             [rems.json :as json]
             [rems.db.core :as db]
+            [rems.db.organizations :as organizations]
             [rems.schema-base :as schema-base]
             [schema.coerce :as coerce]
             [rems.ext.duo :as duo]))
@@ -472,7 +473,7 @@
                                   coerce-DuoCodesDb)]
                 (-> {:catalogue-item/id (:catalogue-item/id resource)
                      :resource/ext-id (:resource/ext-id resource)
-                     :resource/organization (:organization (db/get-resource (:resource-id item)))
+                     :resource/organization (:organization/short-name (organizations/get-organization-by-id-raw (:organization item)))
                      :resource/id (:resource-id item)
                      :catalogue-item/title (localization-for :title item)
                      :catalogue-item/infourl (localization-for :infourl item)


### PR DESCRIPTION
### Changes

- Use the `:organization` id within the `item` variable to get organization information.
- `:resource/organization` is now a localized string object `{ "en": "ADA"}`