### PR TITLE
520 get orcid

### DIFF
--- a/src/clj/rems/cadre_api/cadre_users.clj
+++ b/src/clj/rems/cadre_api/cadre_users.clj
@@ -1,8 +1,8 @@
 (ns rems.cadre-api.cadre-users
   (:require [compojure.api.sweet :refer :all]
             [rems.api.util] ; required for route :roles
-            [rems.db.cadredb.users :as users]
             [rems.config :refer [env]]
+            [rems.ext.comanage :as comanage]
             [ring.util.http-response :refer :all]
             [clojure.tools.logging :as log]
             [rems.util :refer [get-user-id]]))
@@ -11,13 +11,11 @@
   (context "/cadre-users" []
     :tags ["cadre-users"]
 
-    (GET "/role" request
-      :summary "Get role of the current logged-in user"
+    (GET "/orcid" request
+      :summary "Get orcid of self from comanage-registry-url"
       :roles #{:logged-in}
       (let [user-id (get-user-id)
-            response-json (users/fetch-logged-in-user-role user-id)]
-        (when (:log-authentication-details env)
-          (log/info "response-json === " response-json))
+            response-json (comanage/get-user user-id env)]
         {:status 200
          :headers {"Content-Type" "application/json"}
          :body response-json}))))

--- a/src/clj/rems/cadre_api/cadre_users.clj
+++ b/src/clj/rems/cadre_api/cadre_users.clj
@@ -21,15 +21,15 @@
         (ok (get response-json identity))))))
 
 (def cadre-users-api
-  (context "/identities" []
-    :tags ["identities"]
+  (context "/orcid" []
+    :tags ["orcid"]
 
     (GET "/" request
       :summary "Get identity information from yourself from comanage-registry-url"
       :roles #{:logged-in}
-      :query-params [{identity :- (describe s/Str "which user identity value to get") nil}]
       :return s/Any
       (let [user-id (get-user-id)
+            identity "orcid"
             response-json (utils/map-type-to-identity (:Identifier (comanage/get-user user-id env)))]
         (handle-identity-response identity response-json)))
 
@@ -37,7 +37,7 @@
       :summary "Get identity information from a given user by their userid from comanage-registry-url"
       :roles +admin-read-roles+
       :path-params [user :- (describe s/Str "return permissions for this user, required")]
-      :query-params [{identity :- (describe s/Str "which user identity value to get") nil}]
       :return s/Any
-      (let [response-json (utils/map-type-to-identity (:Identifier (comanage/get-user user env)))]
+      (let [identity "orcid"
+            response-json (utils/map-type-to-identity (:Identifier (comanage/get-user user env)))]
         (handle-identity-response identity response-json)))))

--- a/src/clj/rems/cadre_api/cadre_users.clj
+++ b/src/clj/rems/cadre_api/cadre_users.clj
@@ -41,4 +41,3 @@
       :return s/Any
       (let [response-json (utils/map-type-to-identity (:Identifier (comanage/get-user user env)))]
         (handle-identity-response identity response-json)))))
-          

--- a/src/clj/rems/ext/comanage.clj
+++ b/src/clj/rems/ext/comanage.clj
@@ -94,3 +94,17 @@
     (catch Exception e
       (log/error "Error invoking CoManage DELETE API - " "co_group_members.json :" (.getMessage e) (str (getx config :comanage-registry-url) "/co_group_members/" cogroupmemberid ".json")))))
 
+
+(defn get-user
+  "Get a given user's ORCiD"
+  [user-id config]
+  (try
+    (let [url (str (getx config :comanage-registry-url) "/api/co/" (getx config :comanage-registry-coid) "/core/v1/people?identifier=" user-id)
+          response (http/get url (merge +common-opts+ {:basic-auth [(getx config :comanage-core-api-userid) (getx config :comanage-core-api-key)]}))]
+      (if (= 200 (:status response))
+        (let [parsed-json (:body response)
+              id (:0 parsed-json)]
+          id)
+        (throw (ex-info "Non-200 status code returned: " {:response response}))))
+    (catch Exception e
+      (log/error "Error invoking CoManage GET API - " (.getMessage e) (str (getx config :comanage-registry-url) "/api/co/" (getx config :comanage-registry-coid) "/core/v1/people?identifier=" user-id)))))

--- a/src/clj/rems/ext/comanage.clj
+++ b/src/clj/rems/ext/comanage.clj
@@ -96,7 +96,7 @@
 
 
 (defn get-user
-  "Get a given user's ORCiD"
+  "Get a given user's identities"
   [user-id config]
   (try
     (let [url (str (getx config :comanage-registry-url) "/api/co/" (getx config :comanage-registry-coid) "/core/v1/people?identifier=" user-id)

--- a/src/clj/rems/service/cadre/util.clj
+++ b/src/clj/rems/service/cadre/util.clj
@@ -69,3 +69,10 @@
         (is (not (may-edit-project? proj-bob)))
         (is (not (may-edit-project? proj-carl)))
         (is (not (may-edit-project? proj-bob-carl)))))))
+
+;; Hash-Map Identifier CO-Person Record
+(defn map-type-to-identity [seq-of-hmaps]
+  (reduce (fn [acc item]
+            (assoc acc (:type item) (:identifier item)))
+          {}
+          seq-of-hmaps))


### PR DESCRIPTION
# Changelist

- Removed endpoint `[GET] /api/cadre-users/role`
    - Irrelevant endpoint since REMS uses the headers to return the current user's roles
- Added endpoint `[GET] /api/identities`
    - Returns the user (who invoked the endpoint) their own COManage identities mapped `type` to `identifier` 
        - E.g:  `{"oidcsub": "http://cilogon.org/blah/numbers"}`
    - Also included a query-param to narrow down the identity before being returned
        - E.g:  `[GET] /api/identities?identity=orcid => {"orcid": "<orcid>"}`
- Added endpoint `[GET] /api/identities/{user}`
    - Same as the previous endpoint but restricted to admins and can use the path parameter to change the user to request their COManage identities
