### PR TITLE
feat: get all user associated comments

### DIFF
--- a/src/clj/rems/cadre_api/comments.clj
+++ b/src/clj/rems/cadre_api/comments.clj
@@ -53,6 +53,12 @@
       :return CommentDataResponse
       (ok (comments/get-app-comments appid (getx-user-id))))
 
+    (GET "/get-associated-comments" []
+      :summary "Get all comments which are associated to the given user (same application,)"
+      :roles #{:logged-in}
+      :return CommentDataResponse
+      (ok (comments/get-every-app-comments (getx-user-id))))
+
     (GET "/get-my-comments" []
       :summary "Get comments related to me (to and from)"
       :roles #{:logged-in}

--- a/src/clj/rems/cadre_api/comments.clj
+++ b/src/clj/rems/cadre_api/comments.clj
@@ -54,7 +54,7 @@
       (ok (comments/get-app-comments appid (getx-user-id))))
 
     (GET "/get-associated-comments" []
-      :summary "Get all comments which are associated to the given user (same application,)"
+      :summary "Get all comments which are associated to the given user"
       :roles #{:logged-in}
       :return CommentDataResponse
       (ok (comments/get-every-app-comments (getx-user-id))))

--- a/src/clj/rems/db/cadredb/comments.clj
+++ b/src/clj/rems/db/cadredb/comments.clj
@@ -118,6 +118,19 @@
     {:success false
      :errors [{:type :t.get-app-comments.errors/no-app-comments}]}))
 
+(defn get-comments-only  [cmd]
+  (let [comments (db/get-comments cmd)]
+    (if (< 0 (count comments))
+      (remove-nils (mapv add-attach-filename (mapv join-dependencies comments)))
+      comments)))
+
+(defn get-every-app-comments [userid]
+  (if-let [allmyapps (get-the-applications userid)]
+    (let [app-comments (mapcat #(get-comments-only {:appid %}) (map :application/id allmyapps))]
+      {:success true
+       :comments app-comments})
+    {:success false
+     :errors [{:type :t.get-every-app-comments.errors/no-applications}]}))
 
 (defn- markread [cmd comm]
   (jsonattach (-> comm


### PR DESCRIPTION
## Changelist

- New endpoint `[GET] "/get-associated-comments"`
    - Unlike  `[GET] "/get-my-comments"`, this endpoint gets all the comments for all of the user's applications.
    - This includes the applications which they own, applications owned by other people, and applications for their review (if an approver)