### PR TITLE
Unlink orcid - backend

### DIFF
--- a/src/clj/rems/auth/oidc.clj
+++ b/src/clj/rems/auth/oidc.clj
@@ -168,7 +168,7 @@
                 user-data (merge id-data user-info researcher-status)
                 user (find-or-create-user! user-data)]
             (when (:log-authentication-details env)
-              (log/info "logged in" user-data user))
+              (log/info "logged in" access-token id-data user-info researcher-status user))
             (-> (redirect (str (getx env :cadre-url)))
                 (assoc :session (:session request))
                 (assoc-in [:session :access-token] access-token)

--- a/src/clj/rems/cadre_api/cadre_users.clj
+++ b/src/clj/rems/cadre_api/cadre_users.clj
@@ -2,22 +2,35 @@
   (:require [compojure.api.sweet :refer :all]
             [rems.api.util] ; required for route :roles
             [rems.db.cadredb.users :as users]
+            [rems.service.comanage :as comanage]
             [rems.config :refer [env]]
             [ring.util.http-response :refer :all]
+            [rems.api.util :refer [unprocessable-entity-json-response]] ; required for route :roles
             [clojure.tools.logging :as log]
+            [rems.api.schema :as schema]
             [rems.util :refer [get-user-id]]))
 
 (def cadre-users-api
   (context "/cadre-users" []
-    :tags ["cadre-users"]
+           :tags ["cadre-users"]
 
-    (GET "/role" request
-      :summary "Get role of the current logged-in user"
-      :roles #{:logged-in}
-      (let [user-id (get-user-id)
-            response-json (users/fetch-logged-in-user-role user-id)]
-        (when (:log-authentication-details env)
-          (log/info "response-json === " response-json))
-        {:status 200
-         :headers {"Content-Type" "application/json"}
-         :body response-json}))))
+           (GET "/role" request
+                :summary "Get role of the current logged-in user"
+                :roles #{:logged-in}
+                (let [user-id (get-user-id)
+                      response-json (users/fetch-logged-in-user-role user-id)]
+                  (when (:log-authentication-details env)
+                    (log/info "response-json === " response-json))
+                  {:status 200
+                   :headers {"Content-Type" "application/json"}
+                   :body response-json}))
+
+           (POST "/unlink-orcid" []
+                 :summary "Unlink orcid record from comanage registry if exists"
+                 :roles #{:logged-in}
+                 :return schema/SuccessResponse
+                 (let [identifier (comanage/get-orcid-identifier (get-user-id))]
+                   (if (= false identifier) 
+                     (unprocessable-entity-json-response "orcid identifier not found")
+                     (do (comanage/unlink-orcid (get-user-id))       
+                         (ok {:success true})))))))

--- a/src/clj/rems/cadre_api/cadre_users.clj
+++ b/src/clj/rems/cadre_api/cadre_users.clj
@@ -1,12 +1,17 @@
 (ns rems.cadre-api.cadre-users
-  (:require [compojure.api.sweet :refer :all]
-            [rems.api.util] ; required for route :roles
+  (:require [clojure.string :as str]
+            [compojure.api.sweet :refer :all]
+            [rems.api.util :refer [not-found-json-response]]
+            [rems.api.util]
+            [rems.common.roles :refer [+admin-read-roles+]]
             [rems.db.cadredb.users :as users]
+            [rems.service.cadre.util :as utils]
             [rems.service.comanage :as comanage]
             [ring.util.http-response :refer :all]
             [rems.api.util :refer [unprocessable-entity-json-response]] ; required for route :roles
             [clojure.tools.logging :as log]
             [rems.api.schema :as schema]
+            [schema.core :as s]
             [rems.util :refer [get-user-id]]))
 
 
@@ -21,32 +26,33 @@
 
 (def cadre-users-api
   (context "/orcid" []
-           :tags ["orcid"]
+    :tags ["orcid"]
 
-           (GET "/" request
-                :summary "Get identity information from yourself from comanage-registry-url"
-                :roles #{:logged-in}
-                :return s/Any
-                (let [user-id (get-user-id)
-                      identity "orcid"
-                      response-json (utils/map-type-to-identity (:Identifier (comanage/get-user user-id)))]
-                  (handle-identity-response identity response-json)))
+    (GET "/" request
+      :summary "Get identity information from yourself from comanage-registry-url"
+      :roles #{:logged-in}
+      :return s/Any
+      (let [user-id (get-user-id)
+            identity "orcid"
+            response-json (utils/map-type-to-identity (:Identifier (comanage/get-user user-id)))]
+        (handle-identity-response identity response-json)))
 
-           (GET "/:user" request
-                :summary "Get identity information from a given user by their userid from comanage-registry-url"
-                :roles +admin-read-roles+
-                :path-params [user :- (describe s/Str "return permissions for this user, required")]
-                :return s/Any
-                (let [identity "orcid"
-                      response-json (utils/map-type-to-identity (:Identifier (comanage/get-user user)))]
-                  (handle-identity-response identity response-json)))
+    (GET "/:user" request
+      :summary "Get identity information from a given user by their userid from comanage-registry-url"
+      :roles +admin-read-roles+
+      :path-params [user :- (describe s/Str "return permissions for this user, required")]
+      :return s/Any
+      (let [identity "orcid"
+            response-json (utils/map-type-to-identity (:Identifier (comanage/get-user user)))]
+        (handle-identity-response identity response-json)))
 
-           (POST "/unlink-orcid" []
-                 :summary "Unlink orcid record from comanage registry if exists"
-                 :roles #{:logged-in}
-                 :return schema/SuccessResponse
-                 (let [identifier (comanage/get-orcid-identifier (get-user-id))]
-                   (if (= false identifier) 
-                     (unprocessable-entity-json-response "orcid identifier not found")
-                     (do (comanage/unlink-orcid (get-user-id))       
-                         (ok {:success true})))))))
+    (POST "/unlink-orcid" []
+      :summary "Unlink orcid record from comanage registry if exists"
+      :roles #{:logged-in}
+      :return schema/SuccessResponse
+      (let [identifier (comanage/get-orcid-org-id (get-user-id))]
+        (if (nil? identifier)
+          (unprocessable-entity-json-response "orcid identifier not found")
+          (if (nil? (comanage/unlink-orcid identifier))
+            (unprocessable-entity-json-response "cannot unlink identifier")
+            (ok {:success true})))))))

--- a/src/clj/rems/ext/comanage.clj
+++ b/src/clj/rems/ext/comanage.clj
@@ -10,8 +10,8 @@
             [rems.util :refer [getx]]))
 
 (def ^:private +common-opts+
-  {:socket-timeout 2500
-   :conn-timeout 2500
+  {:socket-timeout 5500
+   :conn-timeout 5500
    :as :json})
 
 (defn get-group-member-id
@@ -48,12 +48,36 @@
     (catch Exception e
       (log/error "Error invoking CoManage GET API - " "co_people.json :" (.getMessage e)))))
 
+(defn delete-org-identity
+  "Delete CoManage organisational entity"
+  [orgidentityid]
+  (try
+    (let [url (str (getx env :comanage-registry-url) "/org_identities/" orgidentityid  ".json?coid=" (getx env :comanage-registry-coid))
+          response (http/delete url (merge +common-opts+ {:basic-auth [(getx env :comanage-core-api-userid) (getx env :comanage-core-api-key)]}))]
+      (if (= 200 (:status response))
+        orgidentityid
+        (throw (ex-info "Non-200 status code returned: " {:response response}))))
+    (catch Exception e
+      (log/error "Error invoking CoManage DELETE API - " "org_identities.json :" (.getMessage e)))))
+
+(defn unlink-orcid
+  "Remove orcid link from user by unlinking then deleting the CoManage organisation identity for an orglink (based on user)"
+  [orglink]
+  (try
+    (let [url (str (getx env :comanage-registry-url) "/co_org_identity_links/" (:Id orglink)  ".json?coid=" (getx env :comanage-registry-coid))
+          response (http/delete url (merge +common-opts+ {:basic-auth [(getx env :comanage-core-api-userid) (getx env :comanage-core-api-key)]}))]
+      (if (= 200 (:status response))
+        (delete-org-identity (:OrgIdentityId orglink))
+        (throw (ex-info "Non-200 status code returned: " {:response response}))))
+    (catch Exception e
+      (log/error "Error invoking CoManage DELETE API - " "co_org_identity_links/" (:Id orglink) ".json :" (.getMessage e)))))
+
 (defn get-org-identity-links
   "Get CoManage organisation identiy links for a user"
-  [copersonid config]
+  [copersonid]
   (try
-    (let [url (str (getx config :comanage-registry-url) "/co_org_identity_links.json?coid=" (getx config :comanage-registry-coid) "&copersonid=" copersonid)
-          response (http/get url (merge +common-opts+ {:basic-auth [(getx config :comanage-core-api-userid) (getx config :comanage-core-api-key)]}))]
+    (let [url (str (getx env :comanage-registry-url) "/co_org_identity_links.json?coid=" (getx env :comanage-registry-coid) "&copersonid=" copersonid)
+          response (http/get url (merge +common-opts+ {:basic-auth [(getx env :comanage-core-api-userid) (getx env :comanage-core-api-key)]}))]
       (if (= 200 (:status response))
         (let [parsed-json (:body response)
               orgs (:CoOrgIdentityLinks parsed-json)]
@@ -62,34 +86,23 @@
     (catch Exception e
       (log/error "Error invoking CoManage GET API - " "co_org_identity_links.json :" (.getMessage e)))))
 
-(defn get-orcid-org-id
-  "Get CoManage organisation identity for a user if they have and orcid identifier"
-  [userid config]
-  (let [orgs (get-org-identity-links (get-person-id userid config) config)]
-    (some #(has-orcid-identifiers? %) orgs)))
-
-(defn has-orcid-dentifiers?
-  "Check if orcid identifier"
-  [org]
-  (get-orcid-identifiers (:OrgIdentityId org) config)
-)
-
 (defn get-orcid-identifiers
-  "Get orcid identifiers (if any) from the coidentityid"
-  [coidentityid config]
+  "Get orcid identifiers (if any) from the orgidentityid"
+  [org]
   (try
-    (let [url (str (getx config :comanage-registry-url) "/identifiers.json?coid=" (getx config :comanage-registry-coid) "&coidentityid=" coidentityid)
-          response (http/get url (merge +common-opts+ {:basic-auth [(getx config :comanage-core-api-userid) (getx config :comanage-core-api-key)]}))]
+    (let [url (str (getx env :comanage-registry-url) "/identifiers.json?coid=" (getx env :comanage-registry-coid) "&orgidentityid=" (:OrgIdentityId org))
+          response (http/get url (merge +common-opts+ {:basic-auth [(getx env :comanage-core-api-userid) (getx env :comanage-core-api-key)]}))]
       (if (= 200 (:status response))
         (let [parsed-json (:body response)
               identifiers (:Identifiers parsed-json)
               orcids (filterv #(str/includes? (:Type %) "orcid") identifiers)
               first-identifier (first orcids)
-              id (if (nil? first-identifier) nil coidentityid)]
+              id (if (nil? first-identifier) nil org)]
           id)
         (throw (ex-info "Non-200 status code returned: " {:response response}))))
     (catch Exception e
       (log/error "Error invoking CoManage GET API - " "identifiers.json :" (.getMessage e)))))
+
 
 
 (defn get-group-id
@@ -129,15 +142,15 @@
 
 (defn delete-identifier
   "Delete a CoManage identifier"
-  [identifierid config]
+  [identifierid]
   (try
-    (let [url (str (getx config :comanage-registry-url) "/identifiers/" identifierid ".json")
-          response (http/delete url (merge +common-opts+ {:basic-auth [(getx config :comanage-core-api-userid) (getx config :comanage-core-api-key)]}))]
+    (let [url (str (getx env :comanage-registry-url) "/identifiers/" identifierid ".json")
+          response (http/delete url (merge +common-opts+ {:basic-auth [(getx env :comanage-core-api-userid) (getx env :comanage-core-api-key)]}))]
       (if (= 200 (:status response))
         identifierid
         (throw (ex-info "Non-200 status code returned: " {:response response}))))
     (catch Exception e
-      (log/error "Error invoking CoManage DELETE API - " "identifiers.json :" (.getMessage e) (str (getx config :comanage-registry-url) "/identifiers/" identifierid ".json")))))
+      (log/error "Error invoking CoManage DELETE API - " "identifiers.json :" (.getMessage e) (str (getx env :comanage-registry-url) "/identifiers/" identifierid ".json")))))
 
 
 (defn delete-permissions

--- a/src/clj/rems/ext/comanage.clj
+++ b/src/clj/rems/ext/comanage.clj
@@ -47,19 +47,44 @@
     (catch Exception e
       (log/error "Error invoking CoManage GET API - " "co_people.json :" (.getMessage e)))))
 
-
-(defn get-orcid-identifier
-  "Get CoManage identifier for a given copersonid"
+(defn get-org-identity-links
+  "Get CoManage organisation identiy links for a user"
   [copersonid config]
   (try
-    (let [url (str (getx config :comanage-registry-url) "/identifiers.json?coid=" (getx config :comanage-registry-coid) "&copersonid=" copersonid)
+    (let [url (str (getx config :comanage-registry-url) "/co_org_identity_links.json?coid=" (getx config :comanage-registry-coid) "&copersonid=" copersonid)
+          response (http/get url (merge +common-opts+ {:basic-auth [(getx config :comanage-core-api-userid) (getx config :comanage-core-api-key)]}))]
+      (if (= 200 (:status response))
+        (let [parsed-json (:body response)
+              orgs (:CoOrgIdentityLinks parsed-json)]
+          orgs)
+        (throw (ex-info "Non-200 status code returned: " {:response response}))))
+    (catch Exception e
+      (log/error "Error invoking CoManage GET API - " "co_org_identity_links.json :" (.getMessage e)))))
+
+(defn get-orcid-org-id
+  "Get CoManage organisation identity for a user if they have and orcid identifier"
+  [userid config]
+  (let [orgs (get-org-identity-links (get-person-id userid config) config)]
+    (some #(has-orcid-identifiers? %) orgs)))
+
+(defn has-orcid-dentifiers?
+  "Check if orcid identifier"
+  [org]
+  (get-orcid-identifiers (:OrgIdentityId org) config)
+)
+
+(defn get-orcid-identifiers
+  "Get orcid identifiers (if any) from the coidentityid"
+  [coidentityid config]
+  (try
+    (let [url (str (getx config :comanage-registry-url) "/identifiers.json?coid=" (getx config :comanage-registry-coid) "&coidentityid=" coidentityid)
           response (http/get url (merge +common-opts+ {:basic-auth [(getx config :comanage-core-api-userid) (getx config :comanage-core-api-key)]}))]
       (if (= 200 (:status response))
         (let [parsed-json (:body response)
               identifiers (:Identifiers parsed-json)
               orcids (filterv #(str/includes? (:Type %) "orcid") identifiers)
               first-identifier (first orcids)
-              id (:Id first-identifier)]
+              id (if (nil? first-identifier) nil coidentityid)]
           id)
         (throw (ex-info "Non-200 status code returned: " {:response response}))))
     (catch Exception e

--- a/src/clj/rems/ext/comanage.clj
+++ b/src/clj/rems/ext/comanage.clj
@@ -99,11 +99,11 @@
               first-identifier (first orcids)
               id (if (nil? first-identifier) nil org)]
           id)
-        (throw (ex-info "Non-200 status code returned: " {:response response}))))
+        (if (= 204 (:status response))
+          nil
+          (throw (ex-info "Non-200 status code returned: " {:response response})))))
     (catch Exception e
       (log/error "Error invoking CoManage GET API - " "identifiers.json :" (.getMessage e)))))
-
-
 
 (defn get-group-id
   "Get CoManage group id for a given entitlement resource id"

--- a/src/clj/rems/service/attachment.clj
+++ b/src/clj/rems/service/attachment.clj
@@ -31,7 +31,7 @@
             application-attachment (->> (:application/attachments application)
                                         (find-first #(= attachment-id (:attachment/id %))))
             redacted? (= :filename/redacted (:attachment/filename application-attachment))]
-        (if (some #{:applicant :member :handler :decider} (:application/roles application)) ; user can see all attachments if they are within the application
+        (if (some? application-attachment) ; user can see the attachment
           (assoc-some attachment :attachment/filename (when redacted?
                                                         "redacted"))
           (throw-forbidden))))))

--- a/src/clj/rems/service/comanage.clj
+++ b/src/clj/rems/service/comanage.clj
@@ -33,3 +33,10 @@
                      :remove
                      (comanage/delete-permissions (comanage/get-group-member-id (comanage/get-group-id (:resid entitlement) config) (comanage/get-person-id (:userid entitlement) config) config) config))]
       response)))
+
+(defn get-orcid-identifier [userid]
+  (let [identifier (comanage/get-orcid-identifier (comanage/get-person-id userid env) env)]
+    (if (= nil identifier) false identifier)))
+
+(defn unlink-orcid [userid]
+  (comanage/delete-identifier (comanage/get-orcid-identifier (comanage/get-person-id userid env) env) env))

--- a/src/clj/rems/service/comanage.clj
+++ b/src/clj/rems/service/comanage.clj
@@ -33,9 +33,17 @@
                      (comanage/delete-permissions (comanage/get-group-member-id (comanage/get-group-id (:resid entitlement)) (comanage/get-person-id (:userid entitlement)))))]
       response)))
 
-(defn get-orcid-identifier [userid]
-  (let [identifier (comanage/get-orcid-identifier (comanage/get-person-id userid env) env)]
-    (if (= nil identifier) false identifier)))
 
-(defn unlink-orcid [userid]
-  (comanage/delete-identifier (comanage/get-orcid-identifier (comanage/get-person-id userid env) env) env))
+(defn get-orcid-org-id
+  "Get CoManage organisation identity for a user if they have and orcid identifier"
+  [userid]
+  (let [orgs (comanage/get-org-identity-links (comanage/get-person-id userid))]
+    (some #(comanage/get-orcid-identifiers %) orgs)))
+
+(defn unlink-orcid [orglink]
+  (if (= nil (:Id orglink))
+    nil
+    (comanage/unlink-orcid orglink)))
+
+(defn get-user [user-id]
+  (comanage/get-user user-id))


### PR DESCRIPTION
Backend work towards https://github.com/ADA-ANU/CADRE/issues/518 and https://github.com/ADA-ANU/CADRE/issues/520 

Unlinks the orcid from the comanage registry by finding the related organisational identity and unlinking that from the coperson record, then deletes the organisational identity (which in turn removes the orcid identifiers from the system).

What it doesn't do is call the "revoke" endpoint for orcid itself. I think this would actually have to be done from the comanage registry as that is where the token is created but will need to check that with Scott. 