### PR TITLE
556 retain attachments

### DIFF
--- a/src/clj/rems/application/process_managers.clj
+++ b/src/clj/rems/application/process_managers.clj
@@ -3,6 +3,7 @@
 
   NB: An event manager should return an empty sequence (or `nil`) if it doesn't create new events itself."
   (:require [clojure.set :refer [difference]]
+            [clojure.tools.logging :as log]
             [rems.service.attachment :as attachment]
             [rems.service.blacklist :as blacklist]
             [rems.common.application-util :as application-util]
@@ -36,6 +37,7 @@
         comment-attachments (if (:success application-comments)
                               (->> (:comments application-comments)
                                    (mapcat :attachments)
+                                   (map :id)
                                    (set))
                               #{})
         attachments-in-use (attachment/get-attachments-in-use application)

--- a/src/clj/rems/application/process_managers.clj
+++ b/src/clj/rems/application/process_managers.clj
@@ -7,8 +7,7 @@
             [rems.service.blacklist :as blacklist]
             [rems.common.application-util :as application-util]
             [rems.db.applications :as applications]
-            [rems.db.attachments :as attachments]
-            [rems.db.cadredb.comments :as comments]))
+            [rems.db.attachments :as attachments]))
 
 (defn revokes-to-blacklist
   "Revokation causes the users to be blacklisted."
@@ -32,16 +31,9 @@
 
 (defn delete-orphan-attachments [application-id]
   (let [application (applications/get-application-internal application-id)
-        application-comments (comments/get-comments {:appid application-id})
-        comment-attachments (if (:success application-comments)
-                              (->> (:comments application-comments)
-                                   (mapcat :attachments)
-                                   (map :id)
-                                   (set))
-                              #{})
         attachments-in-use (attachment/get-attachments-in-use application)
         all-attachments (set (map :attachment/id (:application/attachments application)))]
-    (doseq [attachment-id (difference all-attachments attachments-in-use comment-attachments)]
+    (doseq [attachment-id (difference all-attachments attachments-in-use)]
       (attachments/delete-attachment! attachment-id))))
 
 (defn delete-orphan-attachments-on-submit

--- a/src/clj/rems/application/process_managers.clj
+++ b/src/clj/rems/application/process_managers.clj
@@ -7,7 +7,8 @@
             [rems.service.blacklist :as blacklist]
             [rems.common.application-util :as application-util]
             [rems.db.applications :as applications]
-            [rems.db.attachments :as attachments]))
+            [rems.db.attachments :as attachments]
+            [rems.db.cadredb.comments :as comments]))
 
 (defn revokes-to-blacklist
   "Revokation causes the users to be blacklisted."
@@ -31,9 +32,15 @@
 
 (defn delete-orphan-attachments [application-id]
   (let [application (applications/get-application-internal application-id)
+        application-comments (comments/get-comments {:appid application-id})
+        comment-attachments (if (:success application-comments)
+                              (->> (:comments application-comments)
+                                   (mapcat :attachments)
+                                   (set))
+                              #{})
         attachments-in-use (attachment/get-attachments-in-use application)
         all-attachments (set (map :attachment/id (:application/attachments application)))]
-    (doseq [attachment-id (difference all-attachments attachments-in-use)]
+    (doseq [attachment-id (difference all-attachments attachments-in-use comment-attachments)]
       (attachments/delete-attachment! attachment-id))))
 
 (defn delete-orphan-attachments-on-submit

--- a/src/clj/rems/application/process_managers.clj
+++ b/src/clj/rems/application/process_managers.clj
@@ -3,7 +3,6 @@
 
   NB: An event manager should return an empty sequence (or `nil`) if it doesn't create new events itself."
   (:require [clojure.set :refer [difference]]
-            [clojure.tools.logging :as log]
             [rems.service.attachment :as attachment]
             [rems.service.blacklist :as blacklist]
             [rems.common.application-util :as application-util]


### PR DESCRIPTION
### Change

Currently if a user creates a two-way comment before submission, their comment attachments will be removed before submission.

The proposed change is to iterate over the application comments, get all comment attachments in a set, and then include it when calculating the difference between the all-attachments set.