### PR TITLE
feat: return project union for both owner and collaborator

### DIFF
--- a/src/clj/rems/cadre_api/projects.clj
+++ b/src/clj/rems/cadre_api/projects.clj
@@ -54,10 +54,10 @@
     :tags ["CADRE Projects"]
 
     (GET "/" []
-      :summary "Get projects. Returns more information for owners and handlers."
+      :summary "Get projects. If both 'owner' and 'collaborator' are provided, returns the union of projects. Returns more information for owners and handlers."
       :roles #{:logged-in}
-      :query-params [{owner :- (describe s/Str "return only projects that are owned by owner") nil}
-                     {collaborator :- (describe s/Str "return only projects where the user is a collaborator") nil}
+      :query-params [{owner :- (describe s/Str "return projects where the user is an owner") nil}
+                     {collaborator :- (describe s/Str "return projects where the user is a collaborator") nil}
                      {disabled :- (describe s/Bool "whether to include disabled projects") false}
                      {archived :- (describe s/Bool "whether to include archived projects") false}]
       :return [schema-base-cadre/ProjectFull]


### PR DESCRIPTION
### Changes

This merge request is to address the change request proposed in https://github.com/ADA-ANU/CADRE/issues/543

With the existing API, returning projects for users with the owner role where the user was **either** a owner or collaborator was not possible because providing both `/api/cadre-projects?owner={}&collaborator={}` would return the intersect of projects where the owner and the collaborator were both in. 

### Shortcomings

Although the frontend doesn't implement this, the functionality to return the intersect of projects would be useful for future work.