### PR TITLE
feat: unique catalogue-item-ids for new requests

### DIFF
--- a/src/clj/rems/cadre_api/applications.clj
+++ b/src/clj/rems/cadre_api/applications.clj
@@ -215,7 +215,8 @@
         (if (some (partial applications/duplicate-application? (:catalogue-item-ids request)) (applications/get-my-applications (getx-user-id)))
           (ok {:success false
                :errors [{:type :must-not-be-duplicate}]})
-          (ok (api-command :application.command/create request)))))
+          (let [request (update request :catalogue-item-ids distinct)]
+            (ok (api-command :application.command/create request))))))
 
     (POST "/copy-as-new" []
       :summary "Create a new application as a copy of an existing application."


### PR DESCRIPTION
### Original Issue https://github.com/ADA-ANU/CADRE/issues/530 

Currently, as long as all catalogue identifiers passed to `/api/cadre-applications/create` are valid, a DSR is created containing all of these resources. There are no checks to ensure that the ids are all unique from each other and if an array of duplicate ids is POST'ed, the resultant request will contain duplicate resources.

This merge will remove duplicates from `/api/cadre-applications/create` passing it to the create function.


