### PR TITLE
POST Tags in 'create-cannedresponse!'

### DIFF
--- a/src/clj/rems/cadre_api/cannedresponses.clj
+++ b/src/clj/rems/cadre_api/cannedresponses.clj
@@ -12,7 +12,8 @@
 (s/defschema CreateCannedResponseCommand
   {:orgid s/Str
    :response s/Str
-   :title s/Str})
+   :title s/Str
+   (s/optional-key :tags) [s/Int]})
 
 (s/defschema CannedResponseResponse
   {:success s/Bool

--- a/src/clj/rems/cadre_api/cannedresponses.clj
+++ b/src/clj/rems/cadre_api/cannedresponses.clj
@@ -20,6 +20,14 @@
    (s/optional-key :id) s/Int
    (s/optional-key :errors) [s/Any]})
 
+(s/defschema CreateCannedResponseMapping
+  {:success s/Bool
+   :tag s/Int})
+
+(s/defschema CannedResponseAndMappingResponse
+  (merge CannedResponseResponse
+         {(s/optional-key :mapping) [CreateCannedResponseMapping]}))
+
 (s/defschema CannedResponseDataResponse
   {:success s/Bool
    (s/optional-key :cannedresponses) [cannedresponses/CannedResponse]
@@ -88,7 +96,7 @@
       :summary "Create a canned response"
       :roles #{:owner :organization-owner}
       :body [command CreateCannedResponseCommand]
-      :return CannedResponseResponse
+      :return CannedResponseAndMappingResponse
       (ok (cannedresponses/create-cannedresponse! command)))
 
     (POST "/mapping" []

--- a/src/clj/rems/db/cadredb/cannedresponses.clj
+++ b/src/clj/rems/db/cadredb/cannedresponses.clj
@@ -71,7 +71,7 @@
               (doseq [tag tags]
                 (create-cannedresponse-mapping! {:tagid tag :responseid (:id id)}))
               {:success true
-              :id (:id id)}))
+               :id (:id id)}))
           {:success false
            :errors [{:type :t.create-cannedresponse.errors/unable-to-generate}]})
         {:success false

--- a/src/clj/rems/db/cadredb/cannedresponses.clj
+++ b/src/clj/rems/db/cadredb/cannedresponses.clj
@@ -68,7 +68,7 @@
         (if (not (nil? id))
           (if (not (nil? tags))
             (doseq [tag tags]
-              (create-cannedresponse-mapping! {:tagid tag :responseid id}))
+              (create-cannedresponse-mapping! {:tagid tag :responseid (:id id)}))
             {:success true
              :id (:id id)})
           {:success false

--- a/src/clj/rems/db/cadredb/cannedresponses.clj
+++ b/src/clj/rems/db/cadredb/cannedresponses.clj
@@ -67,10 +67,11 @@
       (if-let [id (db/add-canned-response! data)]
         (if (not (nil? id))
           (if (not (nil? tags))
-            (doseq [tag tags]
-              (create-cannedresponse-mapping! {:tagid tag :responseid (:id id)}))
-            {:success true
-             :id (:id id)})
+            (do
+              (doseq [tag tags]
+                (create-cannedresponse-mapping! {:tagid tag :responseid (:id id)}))
+              {:success true
+              :id (:id id)}))
           {:success false
            :errors [{:type :t.create-cannedresponse.errors/unable-to-generate}]})
         {:success false


### PR DESCRIPTION
Extends the JSON body for `POST [/api/cannedresponses` to optionally include tags that are then mapped to the newly created canned response after creation.