### PR TITLE
fix: #574 revoke email notification

### DIFF
--- a/src/clj/rems/email/core.clj
+++ b/src/clj/rems/email/core.clj
@@ -89,13 +89,11 @@
 
 (defn generate-revocation-emails! [invitations]
   (doseq [invitation invitations
-          :when (not (:invitation/revoked invitation))
           :let [email (render-revocation-template invitation)]]
     (enqueue-email! email)))
 
 (defn generate-decline-emails! [invitations]
   (doseq [invitation invitations
-          :when (not (:invitation/declined invitation))
           :let [email (render-decline-template invitation)]]
     (enqueue-email! email)))
 

--- a/src/clj/rems/email/template.clj
+++ b/src/clj/rems/email/template.clj
@@ -355,12 +355,12 @@
          :subject (text-format :t.email.project-handler-revocation/subject
                                (:invitation/name invitation)
                                (get-in invitation [:invitation/revoked-by :name])
-                               (:project/name project))
+                               (get-in project [:project/name :en]))
          :body (str
                 (text-format :t.email.project-handler-revocation/message
                              (:invitation/name invitation)
                              (get-in invitation [:invitation/revoked-by :name])
-                             (:project/name project))
+                             (get-in project [:project/name :en]))
                 (text :t.email/regards)
                 (text :t.email/footer))}))))
 

--- a/src/clj/rems/email/template.clj
+++ b/src/clj/rems/email/template.clj
@@ -367,15 +367,14 @@
 (defn project-decline-email [lang invitation project]
   (with-language lang
     (fn []
-      (let [user (users/get-user (get-in invitation [:invitation/invited-by :userid]))]
-        (when project
-          {:to (:email user)
-           :subject (str :t.email.project-decline/subject)
-           :body (str
-                  (text-format :t.email.project-decline/message
-                               (:name user)
-                               (:invitation/name invitation)
-                               (:invitation/email invitation)
-                               (:project/name project))
-                  (text :t.email/regards)
-                  (text :t.email/footer))})))))
+      (when project
+        {:to (:email user)
+         :subject (str :t.email.project-decline/subject)
+         :body (str
+                (text-format :t.email.project-decline/message
+                             (get-in invitation [:invitation/invited-by :name])
+                             (:invitation/name invitation)
+                             (:invitation/email invitation)
+                             (get-in project [:project/name :en]))
+                (text :t.email/regards)
+                (text :t.email/footer))}))))

--- a/src/clj/rems/service/invitation.clj
+++ b/src/clj/rems/service/invitation.clj
@@ -110,8 +110,8 @@
             (let [project (projects/get-project-by-id-raw project-id)
                   id (:id invitation)]
               (do
-                (email/generate-decline-emails! (get-invitations-full {:ids [id]}))
                 (invitation/decline-invitation! token)
+                (email/generate-decline-emails! (get-invitations-full {:ids [id]}))
                 {:success true}))
             {:success false
              :errors [{:key :t.decline-invitation.errors/invalid-invitation-type}]})
@@ -131,8 +131,8 @@
         (let [project (projects/get-project-by-id-raw project-id)]
           (do
             (rems.service.cadre.util/check-allowed-project! project)
-            (email/generate-revocation-emails! (get-invitations-full {:ids [id]}))
             (invitation/revoke-invitation! userid id)
+            (email/generate-revocation-emails! (get-invitations-full {:ids [id]}))
             (if (= (:invitation/role invitation) "owner")
               (projects/update-project! project-id (fn [project] (-> project
                                                                      (dissoc :project/invitations


### PR DESCRIPTION
### Issue 

https://github.com/ADA-ANU/CADRE/issues/574

### Changes

- Fixed rendering of the project's name within the revoke & decline emails.
- Now the db update occurs before the email is sent.
    -  Because the db had not yet inserted the `:invitation/revoked-by` information for the given invitation, attempting to get the key within `project-handler-revocation-email` was returning a nil and leaving an empty section within the db.
- Removed section for determining the invited-by user's name as that's being populated by the join-dependencies on the invitation before the invitation variable is given to the function.