### PR TITLE
Asset Viewing by Organisation Affiliation

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,13 @@
+FROM clojure:temurin-17-lein-alpine
+
+RUN apk add --no-cache bash
+
+RUN mkdir /rems
+
+WORKDIR /rems
+
+COPY . /rems
+
+RUN lein deps
+
+CMD ["lein", "run"]

--- a/resources/sql/queries.sql
+++ b/resources/sql/queries.sql
@@ -698,6 +698,44 @@ SELECT lic.id, lic.type, lic.enabled, lic.archived, lic.organization
 FROM license lic
 WHERE 
   1=1
+/*~ (when (:associated params) */
+  AND (
+      lic.organization IN (
+      SELECT
+        DISTINCT org.id
+      FROM
+        organization org,
+        LATERAL jsonb_array_elements(org.data->'organization/owners') AS owners
+      WHERE
+        owners->>'userid' = :associated
+    )
+    OR lic.id IN (
+      SELECT                 
+        DISTINCT (jsonb_array_elements(w.workflowbody->'licenses'))::int As forms
+      FROM
+        workflow w,
+        LATERAL jsonb_array_elements_text(w.workflowbody->'handlers') AS handlers
+      WHERE
+        w.enabled = true
+        AND w.archived = false
+        AND handlers::text = :associated
+
+      UNION ALL
+
+      SELECT license.id
+      FROM license
+      INNER JOIN resource_licenses rl ON license.id = rl.licid
+      INNER JOIN resource res ON rl.resid = res.id -- Join resource_licenses with resource
+      INNER JOIN catalogue_item item ON res.id = item.resid
+      INNER JOIN workflow w ON item.wfid = w.id
+      CROSS JOIN LATERAL jsonb_array_elements_text(w.workflowbody->'handlers') AS handlers
+      WHERE
+        w.enabled = true
+        AND w.archived = false
+        AND handlers::text = :associated
+    )
+  )
+/*~ ) ~*/
 /*~ (when (:own params) */
   AND lic.organization IN (
     SELECT
@@ -707,43 +745,6 @@ WHERE
       LATERAL jsonb_array_elements(org.data->'organization/owners') AS owners
     WHERE
       owners->>'userid' = :own
-  )
-/*~ ) ~*/
-/*~ (when (:own-or-associated params) */
-  AND lic.id IN (
-    SELECT                 
-      DISTINCT (jsonb_array_elements(w.workflowbody->'licenses'))::int As forms
-    FROM
-      workflow w,
-      LATERAL jsonb_array_elements_text(w.workflowbody->'handlers') AS handlers
-    WHERE
-      w.enabled = true
-      AND w.archived = false
-      /*~ (when (:own params) */
-      AND handlers::text = :own
-      /*~ ) ~*/
-      /*~ (when (:associated params) */
-      AND handlers::text = :associated
-      /*~ ) ~*/
-
-    UNION ALL
-
-    SELECT license.id
-    FROM license
-    INNER JOIN resource_licenses rl ON license.id = rl.licid
-    INNER JOIN resource res ON rl.resid = res.id -- Join resource_licenses with resource
-    INNER JOIN catalogue_item item ON res.id = item.resid
-    INNER JOIN workflow w ON item.wfid = w.id
-    CROSS JOIN LATERAL jsonb_array_elements_text(w.workflowbody->'handlers') AS handlers
-    WHERE
-      w.enabled = true
-      AND w.archived = false
-      /*~ (when (:own params) */
-      AND handlers::text = :own
-      /*~ ) ~*/
-      /*~ (when (:associated params) */
-      AND handlers::text = :associated
-      /*~ ) ~*/
   )
 /*~ ) ~*/
 ;

--- a/resources/sql/queries.sql
+++ b/resources/sql/queries.sql
@@ -1055,20 +1055,17 @@ WHERE 1=1
           LATERAL jsonb_array_elements(org.data->'organization/owners') AS owners
         WHERE
           owners->>'userid' = :requester
-
-        UNION ALL
-
-        SELECT
-          DISTINCT org.id
-        FROM
-          workflow w,
-          organization org,
-          LATERAL jsonb_array_elements_text(w.workflowbody->'handlers') AS handlers
+      )
+      OR res.id IN (
+        SELECT 
+          DISTINCT item.resid
+        FROM catalogue_item item
+        INNER JOIN workflow w ON item.wfid = w.id
+        CROSS JOIN LATERAL jsonb_array_elements_text(w.workflowbody->'handlers') AS handlers
         WHERE
-          handlers::text = :requester
-          AND w.organization = org.id
-          AND w.enabled = true
+          w.enabled = true
           AND w.archived = false
+          AND handlers::text = :requester
       )
   )
 /*~ ) ~*/

--- a/resources/sql/queries.sql
+++ b/resources/sql/queries.sql
@@ -698,6 +698,17 @@ SELECT lic.id, lic.type, lic.enabled, lic.archived, lic.organization
 FROM license lic
 WHERE 
   1=1
+/*~ (when (:own params) */
+  AND lic.organization IN (
+    SELECT
+      DISTINCT org.id
+    FROM
+      organization org,
+      LATERAL jsonb_array_elements(org.data->'organization/owners') AS owners
+    WHERE
+      owners->>'userid' = :own
+  )
+/*~ ) ~*/
 /*~ (when (:associated params) */
   AND (
       lic.organization IN (
@@ -725,7 +736,7 @@ WHERE
       SELECT license.id
       FROM license
       INNER JOIN resource_licenses rl ON license.id = rl.licid
-      INNER JOIN resource res ON rl.resid = res.id -- Join resource_licenses with resource
+      INNER JOIN resource res ON rl.resid = res.id
       INNER JOIN catalogue_item item ON res.id = item.resid
       INNER JOIN workflow w ON item.wfid = w.id
       CROSS JOIN LATERAL jsonb_array_elements_text(w.workflowbody->'handlers') AS handlers
@@ -734,17 +745,6 @@ WHERE
         AND w.archived = false
         AND handlers::text = :associated
     )
-  )
-/*~ ) ~*/
-/*~ (when (:own params) */
-  AND lic.organization IN (
-    SELECT
-      DISTINCT org.id
-    FROM
-      organization org,
-      LATERAL jsonb_array_elements(org.data->'organization/owners') AS owners
-    WHERE
-      owners->>'userid' = :own
   )
 /*~ ) ~*/
 ;

--- a/resources/sql/queries.sql
+++ b/resources/sql/queries.sql
@@ -302,9 +302,8 @@ WHERE
       UNION
 
       SELECT 
-        DISTINCT lic.id
-      FROM license as lic
-      INNER JOIN catalogue_item item ON lic.id = item.resid
+        DISTINCT item.formid
+      FROM catalogue_item item
       INNER JOIN workflow w ON item.wfid = w.id
       CROSS JOIN LATERAL jsonb_array_elements_text(w.workflowbody->'handlers') AS handlers
       WHERE
@@ -352,9 +351,8 @@ WHERE
       UNION
 
       SELECT 
-        DISTINCT lic.id
-      FROM license as lic
-      INNER JOIN catalogue_item item ON lic.id = item.resid
+        DISTINCT item.formid
+      FROM catalogue_item item
       INNER JOIN workflow w ON item.wfid = w.id
       CROSS JOIN LATERAL jsonb_array_elements_text(w.workflowbody->'handlers') AS handlers
       WHERE

--- a/resources/sql/queries.sql
+++ b/resources/sql/queries.sql
@@ -54,6 +54,31 @@ WHERE 1=1
 /*~ (when-not (nil? (:enabled params)) */
   AND ci.enabled = :enabled
 /*~ ) ~*/
+/*~ (when (:userid params) */
+  AND ci.organization IN (
+    SELECT
+      DISTINCT org.id
+    FROM
+      organization org,
+      LATERAL jsonb_array_elements(org.data->'organization/owners') AS owners
+    WHERE
+      owners->>'userid' = :userid
+
+    UNION ALL
+
+    SELECT
+      DISTINCT org.id
+    FROM
+      workflow w,
+      organization org,
+      LATERAL jsonb_array_elements_text(w.workflowbody->'handlers') AS handlers
+    WHERE
+      handlers::text = :userid
+      AND w.organization = org.id
+      AND w.enabled = true
+      AND w.archived = false
+  )
+/*~ ) ~*/
   ORDER BY ci.id
 /*~ (when (:limit params) */
   LIMIT :limit
@@ -161,6 +186,31 @@ WHERE 1=1
 /*~ (when (:resid params) */
   AND resid = :resid
 /*~ ) ~*/
+/*~ (when (:userid params) */
+  AND organization IN (
+    SELECT
+      DISTINCT org.id
+    FROM
+      organization org,
+      LATERAL jsonb_array_elements(org.data->'organization/owners') AS owners
+    WHERE
+      owners->>'userid' = :userid
+
+    UNION ALL
+
+    SELECT
+      DISTINCT org.id
+    FROM
+      workflow w,
+      organization org,
+      LATERAL jsonb_array_elements_text(w.workflowbody->'handlers') AS handlers
+    WHERE
+      handlers::text = :userid
+      AND w.organization = org.id
+      AND w.enabled = true
+      AND w.archived = false
+  )
+/*~ ) ~*/
 ;
 
 -- :name create-resource! :insert
@@ -213,7 +263,34 @@ SELECT
   fields::TEXT,
   enabled,
   archived
-FROM form_template;
+FROM form_template
+WHERE 
+  1=1
+/*~ (when (:userid params) */
+  AND organization IN (
+    SELECT
+      DISTINCT org.id
+    FROM
+      organization org,
+      LATERAL jsonb_array_elements(org.data->'organization/owners') AS owners
+    WHERE
+      owners->>'userid' = :userid
+
+    UNION ALL
+
+    SELECT
+      DISTINCT org.id
+    FROM
+      workflow w,
+      organization org,
+      LATERAL jsonb_array_elements_text(w.workflowbody->'handlers') AS handlers
+    WHERE
+      handlers::text = :userid
+      AND w.organization = org.id
+      AND w.enabled = true
+      AND w.archived = false
+  )
+/*~ ) ~*/;
 
 -- :name get-form-template :? :1
 SELECT
@@ -224,7 +301,34 @@ SELECT
   enabled,
   archived
 FROM form_template
-WHERE id = :id;
+WHERE 
+  id = :id
+/*~ (when (:userid params) */
+  AND organization IN (
+    SELECT
+      DISTINCT org.id
+    FROM
+      organization org,
+      LATERAL jsonb_array_elements(org.data->'organization/owners') AS owners
+    WHERE
+      owners->>'userid' = :userid
+
+    UNION ALL
+
+    SELECT
+      DISTINCT org.id
+    FROM
+      workflow w,
+      organization org,
+      LATERAL jsonb_array_elements_text(w.workflowbody->'handlers') AS handlers
+    WHERE
+      handlers::text = :userid
+      AND w.organization = org.id
+      AND w.enabled = true
+      AND w.archived = false
+  )
+/*~ ) ~*/
+;
 
 -- :name save-form-template! :insert
 INSERT INTO form_template
@@ -498,12 +602,38 @@ FROM workflow wf
 /*~ (when (:catid params) */
 JOIN catalogue_item ci ON (wf.id = ci.wfid)
 /*~ ) ~*/
-WHERE 1=1
+WHERE 
+  1=1
 /*~ (when (:wfid params) */
-AND wf.id = :wfid
+  AND wf.id = :wfid
 /*~ ) ~*/
 /*~ (when (:catid params) */
-AND ci.id = :catid
+  AND ci.id = :catid
+/*~ ) ~*/
+/*~ (when (:userid params) */
+  AND wf.organization IN (
+    SELECT
+      DISTINCT org.id
+    FROM
+      organization org,
+      LATERAL jsonb_array_elements(org.data->'organization/owners') AS owners
+    WHERE
+      owners->>'userid' = :userid
+
+    UNION ALL
+
+    SELECT
+      DISTINCT org.id
+    FROM
+      workflow w,
+      organization org,
+      LATERAL jsonb_array_elements_text(w.workflowbody->'handlers') AS handlers
+    WHERE
+      handlers::text = :userid
+      AND w.organization = org.id
+      AND w.enabled = true
+      AND w.archived = false
+  )
 /*~ ) ~*/
 ;
 
@@ -511,7 +641,34 @@ AND ci.id = :catid
 SELECT
   wf.id, wf.organization, wf.title,
   wf.workflowBody::TEXT as workflow, wf.enabled, wf.archived
-FROM workflow wf;
+FROM workflow wf
+WHERE 
+  1=1
+/*~ (when (:userid params) */
+  AND wf.organization IN (
+    SELECT
+      DISTINCT org.id
+    FROM
+      organization org,
+      LATERAL jsonb_array_elements(org.data->'organization/owners') AS owners
+    WHERE
+      owners->>'userid' = :userid
+
+    UNION ALL
+
+    SELECT
+      DISTINCT org.id
+    FROM
+      workflow w,
+      organization org,
+      LATERAL jsonb_array_elements_text(w.workflowbody->'handlers') AS handlers
+    WHERE
+      handlers::text = :userid
+      AND w.organization = org.id
+      AND w.enabled = true
+      AND w.archived = false
+  )
+/*~ ) ~*/;
 
 -- :name get-licenses :? :*
 -- :doc
@@ -538,12 +695,66 @@ WHERE rl.resid = :id;
 
 -- :name get-all-licenses :? :*
 SELECT lic.id, lic.type, lic.enabled, lic.archived, lic.organization
-FROM license lic;
+FROM license lic
+WHERE 
+  1=1
+/*~ (when (:userid params) */
+  AND lic.organization IN (
+    SELECT
+      DISTINCT org.id
+    FROM
+      organization org,
+      LATERAL jsonb_array_elements(org.data->'organization/owners') AS owners
+    WHERE
+      owners->>'userid' = :userid
+
+    UNION ALL
+
+    SELECT
+      DISTINCT org.id
+    FROM
+      workflow w,
+      organization org,
+      LATERAL jsonb_array_elements_text(w.workflowbody->'handlers') AS handlers
+    WHERE
+      handlers::text = :userid
+      AND w.organization = org.id
+      AND w.enabled = true
+      AND w.archived = false
+  )
+/*~ ) ~*/;
 
 -- :name get-license :? :1
 SELECT lic.id, lic.type, lic.enabled, lic.archived, lic.organization
 FROM license lic
-WHERE lic.id = :id;
+WHERE 
+  lic.id = :id
+/*~ (when (:userid params) */
+  AND lic.organization IN (
+    SELECT
+      DISTINCT org.id
+    FROM
+      organization org,
+      LATERAL jsonb_array_elements(org.data->'organization/owners') AS owners
+    WHERE
+      owners->>'userid' = :userid
+
+    UNION ALL
+
+    SELECT
+      DISTINCT org.id
+    FROM
+      workflow w,
+      organization org,
+      LATERAL jsonb_array_elements_text(w.workflowbody->'handlers') AS handlers
+    WHERE
+      handlers::text = :userid
+      AND w.organization = org.id
+      AND w.enabled = true
+      AND w.archived = false
+  )
+/*~ ) ~*/
+;
 
 -- :name get-license-localizations :? :*
 SELECT licid, langcode, title, textcontent, attachmentid
@@ -738,11 +949,41 @@ WHERE 1=1
 /*~ (when (:resource/ext-id params) */
   AND eventdata->>'resource/ext-id' = :resource/ext-id
 /*~ ) ~*/
+/*~ (when (:requester params) */
+  AND eventdata->>'resource/ext-id' IN (
+    SELECT
+      res.resid
+    FROM resource res
+    WHERE 
+      res.organization IN (
+        SELECT
+          DISTINCT org.id
+        FROM
+          organization org,
+          LATERAL jsonb_array_elements(org.data->'organization/owners') AS owners
+        WHERE
+          owners->>'userid' = :requester
+
+        UNION ALL
+
+        SELECT
+          DISTINCT org.id
+        FROM
+          workflow w,
+          organization org,
+          LATERAL jsonb_array_elements_text(w.workflowbody->'handlers') AS handlers
+        WHERE
+          handlers::text = :requester
+          AND w.organization = org.id
+          AND w.enabled = true
+          AND w.archived = false
+      )
+  )
+/*~ ) ~*/
 /*~ (when (:userid params) */
   AND eventdata->>'userid' = :userid
 /*~ ) ~*/
-ORDER BY id ASC
-;
+ORDER BY id ASC;
 
 -- :name put-to-outbox! :insert
 INSERT INTO outbox (outboxData)
@@ -894,6 +1135,31 @@ WHERE 1 = 1
 /*~ (when-not (nil? (:enabled params)) */
   AND r.enabled = :enabled
 /*~ ) ~*/
+/*~ (when (:userid params) */
+  AND r.orgId IN (
+    SELECT
+      DISTINCT org.id
+    FROM
+      organization org,
+      LATERAL jsonb_array_elements(org.data->'organization/owners') AS owners
+    WHERE
+      owners->>'userid' = :userid
+
+    UNION ALL
+
+    SELECT
+      DISTINCT org.id
+    FROM
+      workflow w,
+      organization org,
+      LATERAL jsonb_array_elements_text(w.workflowbody->'handlers') AS handlers
+    WHERE
+      handlers::text = :userid
+      AND w.organization = org.id
+      AND w.enabled = true
+      AND w.archived = false
+  )
+/*~ ) ~*/
 ORDER BY r.id ASC;
 
 -- :name get-canned-response-tags :? :*
@@ -916,6 +1182,31 @@ WHERE 1 = 1
 /*~ ) ~*/
 /*~ (when-not (nil? (:enabled params)) */
   AND r.enabled = :enabled
+/*~ ) ~*/
+/*~ (when (:userid params) */
+  AND r.orgId IN (
+    SELECT
+      DISTINCT org.id
+    FROM
+      organization org,
+      LATERAL jsonb_array_elements(org.data->'organization/owners') AS owners
+    WHERE
+      owners->>'userid' = :userid
+
+    UNION ALL
+
+    SELECT
+      DISTINCT org.id
+    FROM
+      workflow w,
+      organization org,
+      LATERAL jsonb_array_elements_text(w.workflowbody->'handlers') AS handlers
+    WHERE
+      handlers::text = :userid
+      AND w.organization = org.id
+      AND w.enabled = true
+      AND w.archived = false
+  )
 /*~ ) ~*/
 ORDER BY r.id ASC;
 

--- a/src/clj/rems/api/blacklist.clj
+++ b/src/clj/rems/api/blacklist.clj
@@ -46,7 +46,8 @@
                      {resource :- s/Str nil}]
       :return [BlacklistEntryWithDetails]
       (ok (blacklist/get-blacklist {:userid (user-mappings/find-userid user)
-                                    :resource/ext-id resource})))
+                                    :resource/ext-id resource
+                                    :requester (getx-user-id)})))
 
     (GET "/users" []
       :summary "Existing REMS users available for adding to the blocklist"

--- a/src/clj/rems/api/forms.clj
+++ b/src/clj/rems/api/forms.clj
@@ -2,7 +2,7 @@
   (:require [compojure.api.sweet :refer :all]
             [rems.service.form :as form]
             [rems.api.schema :as schema]
-            [rems.api.util :refer [determine-proprietorship-choice not-found-json-response]] ; required for route :roles
+            [rems.api.util :refer [add-userid-when-not-owner determine-proprietorship-choice not-found-json-response]] ; required for route :roles
             [rems.common.roles :refer [+admin-read-roles+ +admin-write-roles+]]
             [ring.swagger.json-schema :as rjs]
             [rems.schema-base :as schema-base]
@@ -60,7 +60,8 @@
       :roles +admin-read-roles+
       :path-params [form-id :- (describe s/Int "form-id")]
       :return schema/FormTemplate
-      (let [form (form/get-form-template form-id (getx-user-id))]
+      (let [args (add-userid-when-not-owner [form-id])
+            form (apply form/get-form-template args)]
         (if form
           (ok form)
           (not-found-json-response))))

--- a/src/clj/rems/api/forms.clj
+++ b/src/clj/rems/api/forms.clj
@@ -43,7 +43,8 @@
                      {archived :- (describe s/Bool "whether to include archived forms") false}]
       :return [schema/FormTemplateOverview]
       (ok (get-form-templates (merge (when-not disabled {:enabled true})
-                                     (when-not archived {:archived false})))))
+                                     (when-not archived {:archived false})
+                                     {:userid (getx-user-id)}))))
 
     (POST "/create" []
       :summary "Create form"
@@ -57,7 +58,7 @@
       :roles +admin-read-roles+
       :path-params [form-id :- (describe s/Int "form-id")]
       :return schema/FormTemplate
-      (let [form (form/get-form-template form-id)]
+      (let [form (form/get-form-template form-id (getx-user-id))]
         (if form
           (ok form)
           (not-found-json-response))))

--- a/src/clj/rems/api/forms.clj
+++ b/src/clj/rems/api/forms.clj
@@ -2,7 +2,7 @@
   (:require [compojure.api.sweet :refer :all]
             [rems.service.form :as form]
             [rems.api.schema :as schema]
-            [rems.api.util :refer [not-found-json-response]] ; required for route :roles
+            [rems.api.util :refer [determine-proprietorship-choice not-found-json-response]] ; required for route :roles
             [rems.common.roles :refer [+admin-read-roles+ +admin-write-roles+]]
             [ring.swagger.json-schema :as rjs]
             [rems.schema-base :as schema-base]
@@ -40,11 +40,13 @@
       :summary "Get forms"
       :roles +admin-read-roles+
       :query-params [{disabled :- (describe s/Bool "whether to include disabled forms") false}
-                     {archived :- (describe s/Bool "whether to include archived forms") false}]
+                     {archived :- (describe s/Bool "whether to include archived forms") false}
+                     {proprietorship :- (describe schema/ProprietorshipOptions "return associated or owned licenses, if an owner and param is not provided it will return all licenses but defaults to 'associated' if not an owner role") nil}]
       :return [schema/FormTemplateOverview]
-      (ok (get-form-templates (merge (when-not disabled {:enabled true})
-                                     (when-not archived {:archived false})
-                                     {:userid (getx-user-id)}))))
+      (let [proprietorship-keyword (determine-proprietorship-choice proprietorship)]
+        (ok (get-form-templates (merge (when-not disabled {:enabled true})
+                                       (when-not archived {:archived false})
+                                       (when proprietorship-keyword {proprietorship-keyword (getx-user-id)}))))))
 
     (POST "/create" []
       :summary "Create form"

--- a/src/clj/rems/api/forms.clj
+++ b/src/clj/rems/api/forms.clj
@@ -41,7 +41,7 @@
       :roles +admin-read-roles+
       :query-params [{disabled :- (describe s/Bool "whether to include disabled forms") false}
                      {archived :- (describe s/Bool "whether to include archived forms") false}
-                     {proprietorship :- (describe schema/ProprietorshipOptions "return associated or owned licenses, if an owner and param is not provided it will return all licenses but defaults to 'associated' if not an owner role") nil}]
+                     {proprietorship :- (describe schema/ProprietorshipOptions "return associated or owned forms, if an owner and param is not provided it will return all forms but defaults to 'associated' if not an owner role") nil}]
       :return [schema/FormTemplateOverview]
       (let [proprietorship-keyword (determine-proprietorship-choice proprietorship)]
         (ok (get-form-templates (merge (when-not disabled {:enabled true})

--- a/src/clj/rems/api/licenses.clj
+++ b/src/clj/rems/api/licenses.clj
@@ -47,11 +47,12 @@
       :summary "Get licenses"
       :roles +admin-read-roles+
       :query-params [{disabled :- (describe s/Bool "whether to include disabled licenses") false}
-                     {archived :- (describe s/Bool "whether to include archived licenses") false}]
+                     {archived :- (describe s/Bool "whether to include archived licenses") false}
+                     {return   :- (describe schema/AssetReturn "return associated or own resources") "associated"}]
       :return schema/Licenses
       (ok (licenses/get-all-licenses (merge (when-not disabled {:enabled true})
                                             (when-not archived {:archived false})
-                                            {:userid (getx-user-id)}))))
+                                            {(keyword return) (getx-user-id)}))))
 
     (GET "/:license-id" []
       :summary "Get license"

--- a/src/clj/rems/api/licenses.clj
+++ b/src/clj/rems/api/licenses.clj
@@ -3,7 +3,7 @@
             [rems.api.schema :as schema]
             [rems.service.attachment :as attachment]
             [rems.service.licenses :as licenses]
-            [rems.api.util :refer [determine-proprietorship-choice not-found-json-response]] ; required for route :roles
+            [rems.api.util :refer [add-userid-when-not-owner determine-proprietorship-choice not-found-json-response]] ; required for route :roles
             [rems.common.roles :refer [+admin-read-roles+ +admin-write-roles+]]
             [rems.schema-base :as schema-base]
             [rems.util :refer [getx-user-id]]
@@ -60,9 +60,11 @@
       :roles +admin-read-roles+
       :path-params [license-id :- (describe s/Int "license id")]
       :return schema/License
-      (if-let [license (licenses/get-license license-id (getx-user-id))]
-        (ok license)
-        (not-found-json-response)))
+      (let [args (add-userid-when-not-owner [license-id])
+            license (apply licenses/get-license args)]
+        (if license
+          (ok license)
+          (not-found-json-response))))
 
     (POST "/create" []
       :summary "Create license"

--- a/src/clj/rems/api/licenses.clj
+++ b/src/clj/rems/api/licenses.clj
@@ -50,14 +50,15 @@
                      {archived :- (describe s/Bool "whether to include archived licenses") false}]
       :return schema/Licenses
       (ok (licenses/get-all-licenses (merge (when-not disabled {:enabled true})
-                                            (when-not archived {:archived false})))))
+                                            (when-not archived {:archived false})
+                                            {:userid (getx-user-id)}))))
 
     (GET "/:license-id" []
       :summary "Get license"
       :roles +admin-read-roles+
       :path-params [license-id :- (describe s/Int "license id")]
       :return schema/License
-      (if-let [license (licenses/get-license license-id)]
+      (if-let [license (licenses/get-license license-id (getx-user-id))]
         (ok license)
         (not-found-json-response)))
 

--- a/src/clj/rems/api/resources.clj
+++ b/src/clj/rems/api/resources.clj
@@ -79,7 +79,7 @@
       :return Resource
       (let [args (add-userid-when-not-owner [resource-id])
             resource (apply resource/get-resource args)]
-        (if  
+        (if resource
           (ok resource)
           (not-found-json-response))))
 

--- a/src/clj/rems/api/resources.clj
+++ b/src/clj/rems/api/resources.clj
@@ -75,7 +75,7 @@
       :roles +admin-read-roles+
       :path-params [resource-id :- (describe s/Int "resource id")]
       :return Resource
-      (if-let [resource (resource/get-resource resource-id)]
+      (if-let [resource (resource/get-resource resource-id (getx-user-id))]
         (ok resource)
         (not-found-json-response)))
 

--- a/src/clj/rems/api/resources.clj
+++ b/src/clj/rems/api/resources.clj
@@ -7,6 +7,7 @@
             [rems.ext.duo :as duo]
             [rems.ext.mondo :as mondo]
             [rems.schema-base :as schema-base]
+            [rems.util :refer [getx-user-id]]
             [ring.util.http-response :refer :all]
             [schema.core :as s]))
 
@@ -47,7 +48,8 @@
       :return Resources
       (ok (resource/get-resources (merge (when-not disabled {:enabled true})
                                          (when-not archived {:archived false})
-                                         (when resid {:resid resid})))))
+                                         (when resid {:resid resid})
+                                         {:userid (getx-user-id)}))))
 
     (GET "/duo-codes" []
       :summary "Get DUO codes"

--- a/src/clj/rems/api/schema.clj
+++ b/src/clj/rems/api/schema.clj
@@ -311,5 +311,5 @@
 (s/defschema CatalogueItemFound
   {:success s/Bool})
 
-(s/defschema AssetReturn
+(s/defschema ProprietorshipOptions
   (s/enum "associated" "own"))

--- a/src/clj/rems/api/schema.clj
+++ b/src/clj/rems/api/schema.clj
@@ -310,3 +310,6 @@
 
 (s/defschema CatalogueItemFound
   {:success s/Bool})
+
+(s/defschema AssetReturn
+  (s/enum "associated" "own"))

--- a/src/clj/rems/api/util.clj
+++ b/src/clj/rems/api/util.clj
@@ -62,3 +62,11 @@
       (and (nil? proprietorship) owner?) nil
       (nil? proprietorship) :associated
       :else (keyword proprietorship))))
+
+(defn add-userid-when-not-owner
+  "If the user is an owner, we don't need to pass their userid to filter the result
+  as owners can see all assets"
+  [args]
+  (if (has-roles? :owner)
+    args
+    (conj args (get-user-id))))

--- a/src/clj/rems/api/util.clj
+++ b/src/clj/rems/api/util.clj
@@ -4,6 +4,7 @@
             [ring.util.http-response :as http-response]
             [rems.auth.util :refer [throw-unauthorized throw-forbidden]]
             [rems.common.roles :refer [has-roles?]]
+            [rems.context :as context]
             [rems.json :as json]
             [rems.util :refer [errorf get-user-id]]))
 
@@ -49,3 +50,15 @@
   (let [body (json/generate-string {:error (or message "unprocessable entity")})]
     (-> (http-response/unprocessable-entity body)
         (http-response/content-type "application/json"))))
+
+(defn determine-proprietorship-choice
+  "Determines 'proprietorship' value for queries.
+   - If 'proprietorship' is nil and the user is an owner, it returns nil (meaning 'all').
+   - If 'proprietorship' is nil and the user is NOT an owner, it defaults to :associated.
+   - Otherwise, it converts the provided 'proprietorship' value to a keyword (:associated or :own)."
+  [proprietorship]
+  (let [owner? (contains? context/*roles* :owner)]
+    (cond
+      (and (nil? proprietorship) owner?) nil
+      (nil? proprietorship) :associated
+      :else (keyword proprietorship))))

--- a/src/clj/rems/api/workflows.clj
+++ b/src/clj/rems/api/workflows.clj
@@ -2,7 +2,7 @@
   (:require [compojure.api.sweet :refer :all]
             [rems.api.schema :as schema]
             [rems.service.workflow :as workflow]
-            [rems.api.util :refer [determine-proprietorship-choice not-found-json-response]] ; required for route :roles
+            [rems.api.util :refer [add-userid-when-not-owner determine-proprietorship-choice not-found-json-response]] ; required for route :roles
             [rems.application.events :as events]
             [rems.common.roles :refer [+admin-read-roles+ +admin-write-roles+]]
             [rems.schema-base :as schema-base]
@@ -89,6 +89,8 @@
       :roles +admin-read-roles+
       :path-params [workflow-id :- (describe s/Int "workflow-id")]
       :return schema/Workflow
-      (if-some [wf (workflow/get-workflow workflow-id (getx-user-id))]
-        (ok wf)
-        (not-found-json-response)))))
+      (let [args (add-userid-when-not-owner [workflow-id])
+            wf (apply workflow/get-workflow args)]
+        (if wf
+          (ok wf)
+          (not-found-json-response))))))

--- a/src/clj/rems/api/workflows.clj
+++ b/src/clj/rems/api/workflows.clj
@@ -6,6 +6,7 @@
             [rems.application.events :as events]
             [rems.common.roles :refer [+admin-read-roles+ +admin-write-roles+]]
             [rems.schema-base :as schema-base]
+            [rems.util :refer [getx-user-id]]
             [ring.util.http-response :refer :all]
             [schema.core :as s]))
 
@@ -44,7 +45,8 @@
                      {archived :- (describe s/Bool "whether to include archived workflows") false}]
       :return [schema/Workflow]
       (ok (workflow/get-workflows (merge (when-not disabled {:enabled true})
-                                         (when-not archived {:archived false})))))
+                                         (when-not archived {:archived false})
+                                         {:userid (getx-user-id)}))))
 
     (POST "/create" []
       :summary "Create workflow"
@@ -85,6 +87,6 @@
       :roles +admin-read-roles+
       :path-params [workflow-id :- (describe s/Int "workflow-id")]
       :return schema/Workflow
-      (if-some [wf (workflow/get-workflow workflow-id)]
+      (if-some [wf (workflow/get-workflow workflow-id (getx-user-id))]
         (ok wf)
         (not-found-json-response)))))

--- a/src/clj/rems/cadre_api/cannedresponses.clj
+++ b/src/clj/rems/cadre_api/cannedresponses.clj
@@ -65,7 +65,8 @@
                                                           (when (some? enabled) {:enabled enabled})
                                                           (when (some? orgid) {:orgid orgid})
                                                           (when (some? tagid) {:tagid tagid})
-                                                          (when (some? id) {:id id})))))
+                                                          (when (some? id) {:id id})
+                                                          {:userid (getx-user-id)}))))
 
     (GET "/tag" []
       :summary "Get canned response tags"
@@ -78,7 +79,8 @@
       (ok (cannedresponses/get-cannedresponse-tags (merge     (when (some? appid) {:appid appid})
                                                               (when (some? enabled) {:enabled enabled})
                                                               (when (some? orgid) {:orgid orgid})
-                                                              (when (some? id) {:id id})))))
+                                                              (when (some? id) {:id id})
+                                                              {:userid (getx-user-id)}))))
 
 
     (GET "/get-by-appid" []

--- a/src/clj/rems/cadre_api/catalogue_items.clj
+++ b/src/clj/rems/cadre_api/catalogue_items.clj
@@ -5,6 +5,7 @@
             [rems.service.catalogue :as catalogue]
             [rems.db.core :as db]
             [ring.util.http-response :refer :all]
+            [rems.util :refer [getx-user-id]]
             [schema.core :as s]))
 
 (s/defschema GetCatalogueItemsResponse
@@ -23,15 +24,17 @@
                      {disabled :- (describe s/Bool "whether to include disabled items") false}
                      {expired :- (describe s/Bool "whether to include expired items") false}
                      {limit :- (describe s/Int "the number of records to return (optional)") nil}
-                     {offset :- (describe s/Int "starts on record OFFSET+1 (optional)") nil}]
+                     {offset :- (describe s/Int "starts on record OFFSET+1 (optional)") nil}
+                     {associated :- (describe s/Bool "return only associated catalogue items") false}]
       :return GetCatalogueItemsResponse
       (ok (db/apply-filters
            (merge (when-not expired {:expired false})
                   (when-not disabled {:enabled true})
                   (when-not archived {:archived false}))
-           (catalogue/get-localized-catalogue-items {:resource resource
-                                                     :expand-names? (str/includes? (or expand "") "names")
-                                                     :expand-catalogue-data? true
-                                                     :archived archived
-                                                     :limit limit
-                                                     :offset offset}))))))
+           (catalogue/get-localized-catalogue-items (merge (when associated {:userid (getx-user-id)})
+                                                           {:resource resource
+                                                            :expand-names? (str/includes? (or expand "") "names")
+                                                            :expand-catalogue-data? true
+                                                            :archived archived
+                                                            :limit limit
+                                                            :offset offset})))))))

--- a/src/clj/rems/db/blacklist.clj
+++ b/src/clj/rems/db/blacklist.clj
@@ -55,7 +55,7 @@
                                :eventdata (-> event check-foreign-keys event->json)}))
 
 (defn get-events [params]
-  (mapv event-from-db (db/get-blacklist-events (select-keys params [:userid :resource/ext-id]))))
+  (mapv event-from-db (db/get-blacklist-events (select-keys params [:userid :resource/ext-id :requester]))))
 
 (defn- events->blacklist [events]
   ;; TODO: move computation to db for performance

--- a/src/clj/rems/db/form.clj
+++ b/src/clj/rems/db/form.clj
@@ -56,15 +56,15 @@
        (db/apply-filters (dissoc filters :userid))
        (map add-validation-errors)))
 
-(defn get-form-template 
+(defn get-form-template
   ([id]
-    (let [row (db/get-form-template {:id id})]
-      (when row
-        (add-validation-errors (parse-db-row row)))))
+   (let [row (db/get-form-template {:id id})]
+     (when row
+       (add-validation-errors (parse-db-row row)))))
   ([id userid]
-    (let [row (db/get-form-template {:id id :userid userid})]
-      (when row
-        (add-validation-errors (parse-db-row row))))))
+   (let [row (db/get-form-template {:id id :userid userid})]
+     (when row
+       (add-validation-errors (parse-db-row row))))))
 
 (defn- validate-given-ids
   "Check that `:field/id` values are distinct, not empty (or not given)."

--- a/src/clj/rems/db/form.clj
+++ b/src/clj/rems/db/form.clj
@@ -51,9 +51,9 @@
   (assoc template :form/errors (common-form/validate-form-template template (:languages env))))
 
 (defn get-form-templates [filters]
-  (->> (db/get-form-templates (select-keys filters [:userid]))
+  (->> (db/get-form-templates (select-keys filters [:own :associated]))
        (map parse-db-row)
-       (db/apply-filters (dissoc filters :userid))
+       (db/apply-filters (dissoc filters :own :associated))
        (map add-validation-errors)))
 
 (defn get-form-template

--- a/src/clj/rems/db/form.clj
+++ b/src/clj/rems/db/form.clj
@@ -51,15 +51,20 @@
   (assoc template :form/errors (common-form/validate-form-template template (:languages env))))
 
 (defn get-form-templates [filters]
-  (->> (db/get-form-templates)
+  (->> (db/get-form-templates (select-keys filters [:userid]))
        (map parse-db-row)
-       (db/apply-filters filters)
+       (db/apply-filters (dissoc filters :userid))
        (map add-validation-errors)))
 
-(defn get-form-template [id]
-  (let [row (db/get-form-template {:id id})]
-    (when row
-      (add-validation-errors (parse-db-row row)))))
+(defn get-form-template 
+  ([id]
+    (let [row (db/get-form-template {:id id})]
+      (when row
+        (add-validation-errors (parse-db-row row)))))
+  ([id userid]
+    (let [row (db/get-form-template {:id id :userid userid})]
+      (when row
+        (add-validation-errors (parse-db-row row))))))
 
 (defn- validate-given-ids
   "Check that `:field/id` values are distinct, not empty (or not given)."

--- a/src/clj/rems/db/licenses.clj
+++ b/src/clj/rems/db/licenses.clj
@@ -39,14 +39,14 @@
   "Get a single license by id"
   ([id]
    (when-let [license (db/get-license {:id id})]
-    (->> license
-         (format-license)
-         (localize-license (get-license-localizations)))))
+     (->> license
+          (format-license)
+          (localize-license (get-license-localizations)))))
   ([id userid]
    (when-let [license (db/get-license {:id id :userid userid})]
-    (->> license
-         (format-license)
-         (localize-license (get-license-localizations))))))
+     (->> license
+          (format-license)
+          (localize-license (get-license-localizations))))))
 
 (defn get-all-licenses
   "Get all licenses.

--- a/src/clj/rems/db/licenses.clj
+++ b/src/clj/rems/db/licenses.clj
@@ -1,6 +1,7 @@
 (ns rems.db.licenses
   "querying localized licenses"
   (:require [medley.core :refer [distinct-by]]
+            [rems.context :as context]
             [rems.db.core :as db]))
 
 (defn- format-license [license]
@@ -53,7 +54,7 @@
 
    filters is a map of key-value pairs that must be present in the licenses"
   [filters]
-  (->> (db/get-all-licenses (assoc (select-keys filters [:own :associated]) :own-or-associated (or (contains? filters :own) (contains? filters :associated))))
+  (->> (db/get-all-licenses (select-keys filters [:own :associated]))
        (db/apply-filters (dissoc filters :own :associated))
        (format-licenses)
        (localize-licenses)))

--- a/src/clj/rems/db/licenses.clj
+++ b/src/clj/rems/db/licenses.clj
@@ -53,8 +53,8 @@
 
    filters is a map of key-value pairs that must be present in the licenses"
   [filters]
-  (->> (db/get-all-licenses (select-keys filters [:userid]))
-       (db/apply-filters (dissoc filters :userid))
+  (->> (db/get-all-licenses (assoc (select-keys filters [:own :associated]) :own-or-associated (or (:own filters) (:associated filters))))
+       (db/apply-filters (dissoc filters :own :associated))
        (format-licenses)
        (localize-licenses)))
 

--- a/src/clj/rems/db/licenses.clj
+++ b/src/clj/rems/db/licenses.clj
@@ -53,7 +53,7 @@
 
    filters is a map of key-value pairs that must be present in the licenses"
   [filters]
-  (->> (db/get-all-licenses (assoc (select-keys filters [:own :associated]) :own-or-associated (or (:own filters) (:associated filters))))
+  (->> (db/get-all-licenses (assoc (select-keys filters [:own :associated]) :own-or-associated (or (contains? filters :own) (contains? filters :associated))))
        (db/apply-filters (dissoc filters :own :associated))
        (format-licenses)
        (localize-licenses)))

--- a/src/clj/rems/db/licenses.clj
+++ b/src/clj/rems/db/licenses.clj
@@ -37,19 +37,24 @@
 
 (defn get-license
   "Get a single license by id"
-  [id]
-  (when-let [license (db/get-license {:id id})]
+  ([id]
+   (when-let [license (db/get-license {:id id})]
     (->> license
          (format-license)
          (localize-license (get-license-localizations)))))
+  ([id userid]
+   (when-let [license (db/get-license {:id id :userid userid})]
+    (->> license
+         (format-license)
+         (localize-license (get-license-localizations))))))
 
 (defn get-all-licenses
   "Get all licenses.
 
    filters is a map of key-value pairs that must be present in the licenses"
   [filters]
-  (->> (db/get-all-licenses)
-       (db/apply-filters filters)
+  (->> (db/get-all-licenses (select-keys filters [:userid]))
+       (db/apply-filters (dissoc filters :userid))
        (format-licenses)
        (localize-licenses)))
 

--- a/src/clj/rems/db/resource.clj
+++ b/src/clj/rems/db/resource.clj
@@ -29,15 +29,21 @@
         (dissoc :resourcedata)
         (merge resourcedata))))
 
-(defn get-resource [id]
-  (when-let [resource (db/get-resource {:id id})]
+(defn get-resource 
+  ([id]
+   (when-let [resource (db/get-resource {:id id})]
     (-> resource
         format-resource
         coerce-ResourceDb)))
+  ([id userid]
+   (when-let [resource (db/get-resource {:id id :userid userid})]
+    (-> resource
+        format-resource
+        coerce-ResourceDb))))
 
 (defn get-resources [filters]
-  (->> (db/get-resources (select-keys filters [:resid]))
-       (db/apply-filters (dissoc filters :resid)) ; other filters
+  (->> (db/get-resources (select-keys filters [:resid :userid]))
+       (db/apply-filters (dissoc filters :resid :userid)) ; other filters
        (map format-resource)
        (map coerce-ResourceDb)))
 

--- a/src/clj/rems/db/resource.clj
+++ b/src/clj/rems/db/resource.clj
@@ -29,17 +29,17 @@
         (dissoc :resourcedata)
         (merge resourcedata))))
 
-(defn get-resource 
+(defn get-resource
   ([id]
    (when-let [resource (db/get-resource {:id id})]
-    (-> resource
-        format-resource
-        coerce-ResourceDb)))
+     (-> resource
+         format-resource
+         coerce-ResourceDb)))
   ([id userid]
    (when-let [resource (db/get-resource {:id id :userid userid})]
-    (-> resource
-        format-resource
-        coerce-ResourceDb))))
+     (-> resource
+         format-resource
+         coerce-ResourceDb))))
 
 (defn get-resources [filters]
   (->> (db/get-resources (select-keys filters [:resid :userid]))

--- a/src/clj/rems/db/resource.clj
+++ b/src/clj/rems/db/resource.clj
@@ -42,8 +42,8 @@
          coerce-ResourceDb))))
 
 (defn get-resources [filters]
-  (->> (db/get-resources (select-keys filters [:resid :userid]))
-       (db/apply-filters (dissoc filters :resid :userid)) ; other filters
+  (->> (db/get-resources (select-keys filters [:resid :own :associated]))
+       (db/apply-filters (dissoc filters :resid :own :associated)) ; other filters
        (map format-resource)
        (map coerce-ResourceDb)))
 

--- a/src/clj/rems/db/workflow.clj
+++ b/src/clj/rems/db/workflow.clj
@@ -45,9 +45,9 @@
      (enrich-and-format-workflow wf))))
 
 (defn get-workflows [filters]
-  (->> (db/get-workflows (select-keys filters [:userid]))
+  (->> (db/get-workflows (select-keys filters [:own :associated]))
        (map enrich-and-format-workflow)
-       (db/apply-filters (dissoc filters :userid))))
+       (db/apply-filters (dissoc filters :own :associated))))
 
 (defn get-all-workflow-roles [userid]
   (when (some #(contains? (set (map :userid (get-in % [:workflow :handlers]))) userid)

--- a/src/clj/rems/db/workflow.clj
+++ b/src/clj/rems/db/workflow.clj
@@ -36,13 +36,13 @@
       (update-in [:workflow :licenses] #(mapv (fn [id] {:license/id id}) %))
       (update-in [:workflow :handlers] #(mapv users/get-user %))))
 
-(defn get-workflow 
+(defn get-workflow
   ([id]
    (when-let [wf (db/get-workflow {:wfid id})]
-    (enrich-and-format-workflow wf)))
+     (enrich-and-format-workflow wf)))
   ([id userid]
    (when-let [wf (db/get-workflow {:wfid id :userid userid})]
-    (enrich-and-format-workflow wf))))
+     (enrich-and-format-workflow wf))))
 
 (defn get-workflows [filters]
   (->> (db/get-workflows (select-keys filters [:userid]))

--- a/src/clj/rems/db/workflow.clj
+++ b/src/clj/rems/db/workflow.clj
@@ -36,14 +36,18 @@
       (update-in [:workflow :licenses] #(mapv (fn [id] {:license/id id}) %))
       (update-in [:workflow :handlers] #(mapv users/get-user %))))
 
-(defn get-workflow [id]
-  (when-let [wf (db/get-workflow {:wfid id})]
+(defn get-workflow 
+  ([id]
+   (when-let [wf (db/get-workflow {:wfid id})]
     (enrich-and-format-workflow wf)))
+  ([id userid]
+   (when-let [wf (db/get-workflow {:wfid id :userid userid})]
+    (enrich-and-format-workflow wf))))
 
 (defn get-workflows [filters]
-  (->> (db/get-workflows)
+  (->> (db/get-workflows (select-keys filters [:userid]))
        (map enrich-and-format-workflow)
-       (db/apply-filters filters)))
+       (db/apply-filters (dissoc filters :userid))))
 
 (defn get-all-workflow-roles [userid]
   (when (some #(contains? (set (map :userid (get-in % [:workflow :handlers]))) userid)

--- a/src/clj/rems/service/form.clj
+++ b/src/clj/rems/service/form.clj
@@ -51,9 +51,13 @@
     (->> form
          organizations/join-organization)))
 
-(defn get-form-template [id]
-  (-> (form/get-form-template id)
-      join-dependencies))
+(defn get-form-template 
+  ([id]
+    (-> (form/get-form-template id)
+        join-dependencies))
+  ([id userid]
+    (-> (form/get-form-template id userid)
+        join-dependencies)))
 
 (defn get-form-templates [filters]
   (->> (form/get-form-templates filters)

--- a/src/clj/rems/service/form.clj
+++ b/src/clj/rems/service/form.clj
@@ -51,13 +51,13 @@
     (->> form
          organizations/join-organization)))
 
-(defn get-form-template 
+(defn get-form-template
   ([id]
-    (-> (form/get-form-template id)
-        join-dependencies))
+   (-> (form/get-form-template id)
+       join-dependencies))
   ([id userid]
-    (-> (form/get-form-template id userid)
-        join-dependencies)))
+   (-> (form/get-form-template id userid)
+       join-dependencies)))
 
 (defn get-form-templates [filters]
   (->> (form/get-form-templates filters)

--- a/src/clj/rems/service/licenses.clj
+++ b/src/clj/rems/service/licenses.clj
@@ -62,9 +62,12 @@
 
 (defn get-license
   "Get a single license by id"
-  [id]
-  (when-let [license (licenses/get-license id)]
+  ([id]
+   (when-let [license (licenses/get-license id)]
     (organizations/join-organization license)))
+  ([id userid]
+   (when-let [license (licenses/get-license id userid)]
+      (organizations/join-organization license))))
 
 (defn set-license-enabled! [{:keys [id enabled]}]
   (util/check-allowed-organization! (:organization (get-license id)))

--- a/src/clj/rems/service/licenses.clj
+++ b/src/clj/rems/service/licenses.clj
@@ -64,10 +64,10 @@
   "Get a single license by id"
   ([id]
    (when-let [license (licenses/get-license id)]
-    (organizations/join-organization license)))
+     (organizations/join-organization license)))
   ([id userid]
    (when-let [license (licenses/get-license id userid)]
-      (organizations/join-organization license))))
+     (organizations/join-organization license))))
 
 (defn set-license-enabled! [{:keys [id enabled]}]
   (util/check-allowed-organization! (:organization (get-license id)))

--- a/src/clj/rems/service/resource.clj
+++ b/src/clj/rems/service/resource.clj
@@ -16,13 +16,13 @@
          (duo/join-duo-codes [:resource/duo :duo/codes])
          (transform [:licenses ALL] organizations/join-organization))))
 
-(defn get-resource 
+(defn get-resource
   ([id]
    (when-let [resource (resource/get-resource id)]
-    (join-dependencies resource)))
+     (join-dependencies resource)))
   ([id userid]
    (when-let [resource (resource/get-resource id userid)]
-    (join-dependencies resource))))
+     (join-dependencies resource))))
 
 (defn get-resources [filters]
   (->> (resource/get-resources filters)

--- a/src/clj/rems/service/resource.clj
+++ b/src/clj/rems/service/resource.clj
@@ -16,9 +16,13 @@
          (duo/join-duo-codes [:resource/duo :duo/codes])
          (transform [:licenses ALL] organizations/join-organization))))
 
-(defn get-resource [id]
-  (when-let [resource (resource/get-resource id)]
+(defn get-resource 
+  ([id]
+   (when-let [resource (resource/get-resource id)]
     (join-dependencies resource)))
+  ([id userid]
+   (when-let [resource (resource/get-resource id userid)]
+    (join-dependencies resource))))
 
 (defn get-resources [filters]
   (->> (resource/get-resources filters)

--- a/src/clj/rems/service/workflow.clj
+++ b/src/clj/rems/service/workflow.clj
@@ -79,9 +79,13 @@
         (update-in [:workflow :forms] (partial map enrich-workflow-form))
         (update-in [:workflow :licenses] (partial map enrich-workflow-license)))))
 
-(defn get-workflow [id]
-  (->> (workflow/get-workflow id)
+(defn get-workflow 
+  ([id]
+   (->> (workflow/get-workflow id)
        join-dependencies))
+  ([id userid]
+   (->> (workflow/get-workflow id userid)
+       join-dependencies)))
 
 (defn get-workflows [filters]
   (->> (workflow/get-workflows filters)

--- a/src/clj/rems/service/workflow.clj
+++ b/src/clj/rems/service/workflow.clj
@@ -79,13 +79,13 @@
         (update-in [:workflow :forms] (partial map enrich-workflow-form))
         (update-in [:workflow :licenses] (partial map enrich-workflow-license)))))
 
-(defn get-workflow 
+(defn get-workflow
   ([id]
    (->> (workflow/get-workflow id)
-       join-dependencies))
+        join-dependencies))
   ([id userid]
    (->> (workflow/get-workflow id userid)
-       join-dependencies)))
+        join-dependencies)))
 
 (defn get-workflows [filters]
   (->> (workflow/get-workflows filters)


### PR DESCRIPTION
### Changes

- Dropdowns for creating objects (forms, resources, catalogue-items) should not show organisations assets or blocked users that the given user cannot create objects for.
- Handlers should not be able to see other organisation's assets or blocked users

### Original Issue

https://github.com/ADA-ANU/CADRE/issues/582