### PR TITLE
feat: filter application licenses by enabled & not archived

### DIFF
--- a/src/cljc/rems/common/application_util.cljc
+++ b/src/cljc/rems/common/application_util.cljc
@@ -3,7 +3,10 @@
             [rems.common.util :as util]))
 
 (defn accepted-licenses? [application userid]
-  (let [application-licenses (map :license/id (:application/licenses application))
+  (let [application-licenses (->> application
+                                  :application/licenses
+                                  (filter #(and (:license/enabled %) (false? (:license/archived %))))
+                                  (map :license/id))
         user-accepted-licenses (get (:application/accepted-licenses application) userid)]
     (cond (empty? application-licenses) true
           (empty? user-accepted-licenses) false


### PR DESCRIPTION
### Issue

https://github.com/ADA-ANU/CADRE/issues/621

### Changes

- When performing the `accepted-licenses?` check, the disabled and archived licenses are omitted from the check
    - Although licenses can be disabled while still being associated with a resource, a license cannot be archived. For this reason, the `(false? (:license/archived %))` is probably irrelevant and could potentially be removed.