### PR TITLE
feat: LIKE search for catalogue items

### DIFF
--- a/resources/sql/queries.sql
+++ b/resources/sql/queries.sql
@@ -6,6 +6,7 @@
 -- - Get catalogue items
 -- - :ids vector of item ids
 -- - :resource resource external id to fetch items for
+-- - :resource-like match resource external id by pattern for fetch items 
 -- - :resource-id resource internal id to fetch items for
 -- - :workflow workflow id to fetch items for
 -- - :form form id to fetch items for

--- a/resources/sql/queries.sql
+++ b/resources/sql/queries.sql
@@ -39,6 +39,9 @@ WHERE 1=1
 /*~ (when (:resource params) */
   AND res.resid = :resource
 /*~ ) ~*/
+/*~ (when (:resource-like params) */
+  AND res.resid LIKE :resource-like
+/*~ ) ~*/
 /*~ (when (:resource-id params) */
   AND ci.resid = :resource-id
 /*~ ) ~*/

--- a/src/clj/rems/api/catalogue.clj
+++ b/src/clj/rems/api/catalogue.clj
@@ -58,7 +58,8 @@
       :query-params [{resource :- (describe s/Str "resource id") ""}]
       :responses {200 {:schema schema/CatalogueItemFound}
                   404 {:schema s/Any :description "Not found"}}
-      (if-let [it (first (catalogue/get-localized-catalogue-items {:resource resource
-                                                                   :enabled true}))]  ; TODO, hotfix because path param fails for string with slashes
-        (ok {:success true})
+      (if-let [resources (catalogue/get-localized-catalogue-items {:resource-like (str "%" resource "%")
+                                                                   :enabled true})]
+        (ok {:success true
+             :results (count resources)})
         (not-found-json-response)))))

--- a/src/clj/rems/api/catalogue.clj
+++ b/src/clj/rems/api/catalogue.clj
@@ -58,8 +58,9 @@
       :query-params [{resource :- (describe s/Str "resource id") ""}]
       :responses {200 {:schema schema/CatalogueItemFound}
                   404 {:schema s/Any :description "Not found"}}
-      (if-let [resources (catalogue/get-localized-catalogue-items {:resource-like (str "%" resource "%")
+      (let [resources (catalogue/get-localized-catalogue-items {:resource-like (str "%" resource "%")
                                                                    :enabled true})]
-        (ok {:success true
-             :results (count resources)})
-        (not-found-json-response)))))
+        (if (not (empty? resources))
+          (ok {:success true
+               :results (count resources)})
+          (not-found-json-response))))))

--- a/src/clj/rems/api/schema.clj
+++ b/src/clj/rems/api/schema.clj
@@ -309,7 +309,8 @@
   schema-base/CategoryId)
 
 (s/defschema CatalogueItemFound
-  {:success s/Bool})
+  {:success s/Bool
+   :results s/Int})
 
 (s/defschema ProprietorshipOptions
   (s/enum "associated" "own"))


### PR DESCRIPTION
## Changes

- Extended `get-catalogue-items (src/rems/resources/sql/queries.sql)` to include a new parameter ':resource-like'. Passing this parameter will match resource's external ids by the parameter's pattern.
    - E.g., if we have two resources `doi:10.80408/YVGPK2-General` and `doi:10.80408/YVGPK2-Restricted` and we set the value `:resource-like '%doi:10.80408/YVGPK2%'`, we will be able to return both catalogue items using the query.  
- Updated `/api/catalogue/resource` to search the localized catalogue items by using the `:resource-like` parameter instead of `:resource`.
- Extended the schema and return JSON for `/api/catalogue/resource` to include a `results` key that correlates to the number of matched catalogue items.

## Planned Implementation & Integration with Dataverse

These changes allow for the existing dataverse code that lies within the footer to call `/api/catalogue/resource` and check whether a dataset (or any deliminator separated dataset subsets) may or may not exist within CADRE. E.g., the catalogue items `doi:10.80408/YVGPK2-General` and `doi:10.80408/YVGPK2-Restricted` would still be found within CADRE when the dataverse footer searches for `doi:10.80408/YVGPK2`.