### PR TITLE
Prevent non-duplicate applications by changing-resources & extend filter for catalogue item searches

### DIFF
--- a/src/clj/rems/cadre_api/catalogue_items.clj
+++ b/src/clj/rems/cadre_api/catalogue_items.clj
@@ -25,7 +25,8 @@
                      {expired :- (describe s/Bool "whether to include expired items") false}
                      {limit :- (describe s/Int "the number of records to return (optional)") nil}
                      {offset :- (describe s/Int "starts on record OFFSET+1 (optional)") nil}
-                     {associated :- (describe s/Bool "return only associated catalogue items") false}]
+                     {associated :- (describe s/Bool "return only associated catalogue items") false}
+                     {requested :- (describe s/Bool "whether to include items with pre-existing requests (optional)") true}]
       :return GetCatalogueItemsResponse
       (ok (db/apply-filters
            (merge (when-not expired {:expired false})
@@ -37,4 +38,5 @@
                                                             :expand-catalogue-data? true
                                                             :archived archived
                                                             :limit limit
-                                                            :offset offset})))))))
+                                                            :offset offset
+                                                            :requested requested})))))))


### PR DESCRIPTION
## Changes

1. Updated `[GET] /api/cadre-catalogue-items` to optionally filter catalogue-items which are already requested
    - Not providing `requested` or setting it as `?requested=true` will include the catalogue items which already have been requested in existing applications.
    - Setting the `requested` query parameter as `?requested=false` will filter the catalogue items which have already been requested in existing applications.
2. Updated `[POST] /api/cadre-applications/change-resources` to prevent changing resources to resources which already have been requested.
    - If existing applications are found to include any of the same catalogue items that this application being changed to include, the API will return `[200] {"success": false, "errors": [{"type": "must-not-be-duplicate"}]}`.

## Reasoning

- When the changing resources we do not want to allow users to have duplicate applications for the same resources. 
    - The change to the `[POST] /api/cadre-applications/change-resources` API endpoint prevents this.
- When populating the options for the user to select when choosing what resources they can change their request to, we want to filter catalogue items with existing requests without having to call `[GET] /api/cadre-my-applications` as well.



