### PR TITLE
feat: add project users upload

### DIFF
--- a/src/clj/rems/application/commands.clj
+++ b/src/clj/rems/application/commands.clj
@@ -3,7 +3,6 @@
             [clojure.set]
             [medley.core :refer [assoc-some distinct-by find-first update-existing]]
             [rems.common.application-util :as application-util]
-            [clojure.tools.logging :as log]
             [rems.common.form :as form]
             [rems.form-validation :as form-validation]
             [rems.permissions :as permissions]
@@ -575,14 +574,7 @@
            :application/member (:member cmd)})))
 
 (defmethod command-handler :application.command/invite-member
-  [cmd application {:keys [secure-token]}]
-  ;; Extend this to include project information
-
-  ;; (count (get application :application/projects []))>0
-  ;; (do
-  ;;   (log/warn (count (get application :application/projects [])))))
-    ;; {:errors [{:type :must-not-be-empty :key key}]}))
-
+  [cmd _application {:keys [secure-token]}]
   (ok {:event/type :application.event/member-invited
        :application/member (:member cmd)
        :invitation/token (secure-token)}))

--- a/src/clj/rems/application/commands.clj
+++ b/src/clj/rems/application/commands.clj
@@ -3,6 +3,7 @@
             [clojure.set]
             [medley.core :refer [assoc-some distinct-by find-first update-existing]]
             [rems.common.application-util :as application-util]
+            [clojure.tools.logging :as log]
             [rems.common.form :as form]
             [rems.form-validation :as form-validation]
             [rems.permissions :as permissions]
@@ -574,7 +575,14 @@
            :application/member (:member cmd)})))
 
 (defmethod command-handler :application.command/invite-member
-  [cmd _application {:keys [secure-token]}]
+  [cmd application {:keys [secure-token]}]
+  ;; Extend this to include project information
+  
+  ;; (count (get application :application/projects []))>0
+  ;; (do
+  ;;   (log/warn (count (get application :application/projects [])))))
+    ;; {:errors [{:type :must-not-be-empty :key key}]}))
+  
   (ok {:event/type :application.event/member-invited
        :application/member (:member cmd)
        :invitation/token (secure-token)}))

--- a/src/clj/rems/application/commands.clj
+++ b/src/clj/rems/application/commands.clj
@@ -577,12 +577,12 @@
 (defmethod command-handler :application.command/invite-member
   [cmd application {:keys [secure-token]}]
   ;; Extend this to include project information
-  
+
   ;; (count (get application :application/projects []))>0
   ;; (do
   ;;   (log/warn (count (get application :application/projects [])))))
     ;; {:errors [{:type :must-not-be-empty :key key}]}))
-  
+
   (ok {:event/type :application.event/member-invited
        :application/member (:member cmd)
        :invitation/token (secure-token)}))

--- a/src/clj/rems/cadre_api/applications.clj
+++ b/src/clj/rems/cadre_api/applications.clj
@@ -303,7 +303,7 @@
       :body [request commands/ChangeResourcesCommand]
       :return s/Any
       ;; Remove this application to allow including more resources in addition to the current resource(s)
-      (let [applications (applications/get-my-applications (getx-user-id))
+      (let [applications (applications/get-my-applications (getx-user-id)) ;; TODO - this should actually refer to the main-applicant
             existing-applications (remove-first-match #(= (:application-id request) (:application/id %))
                                                       applications)]
         (if (some (partial applications/duplicate-application? (:catalogue-item-ids request)) existing-applications)

--- a/src/clj/rems/cadre_api/projects.clj
+++ b/src/clj/rems/cadre_api/projects.clj
@@ -1,10 +1,10 @@
 (ns rems.cadre-api.projects
   (:require [compojure.api.sweet :refer :all]
-            [clojure.tools.logging :as log]
             [rems.api.schema :as schema]
             [rems.api.util :refer [not-found-json-response]] ; required for route :roles
             [rems.schema-base :as schema-base]
             [rems.schema-base-cadre :as schema-base-cadre]
+            [rems.service.cadre.parse-users :refer [upload-handler]]
             [rems.service.cadre.projects :as projects]
             [rems.util :refer [getx-user-id]]
             [ring.util.http-response :refer :all]
@@ -166,4 +166,11 @@
       :return schema-base-cadre/ProjectFull
       (if-let [project (projects/get-project (getx-user-id) {:project/id project-id})]
         (ok project)
-        (not-found-json-response)))))
+        (not-found-json-response)))
+    
+    (POST "/parse-users" [] 
+      :summary "Parse a csv of users into json for reference"
+      :roles #{:logged-in}
+      :multipart-params [file :- schema/FileUpload]
+      :return s/Any
+      (ok (upload-handler file)))))

--- a/src/clj/rems/cadre_api/projects.clj
+++ b/src/clj/rems/cadre_api/projects.clj
@@ -167,8 +167,8 @@
       (if-let [project (projects/get-project (getx-user-id) {:project/id project-id})]
         (ok project)
         (not-found-json-response)))
-    
-    (POST "/parse-users" [] 
+
+    (POST "/parse-users" []
       :summary "Parse a csv of users into json for reference"
       :roles #{:logged-in}
       :multipart-params [file :- schema/FileUpload]

--- a/src/clj/rems/service/cadre/parse_users.clj
+++ b/src/clj/rems/service/cadre/parse_users.clj
@@ -1,0 +1,74 @@
+(ns rems.service.cadre.parse-users
+  (:require [clojure.data.csv :as csv]
+            [clojure.java.io :as io]
+            [clojure.string :as str]
+            [clojure.tools.logging :as log]))
+
+(def allowed-content-types
+  #{"text/csv" "application/vnd.ms-excel" "application/csv"})
+
+(defn normalize-header-term [term]
+  (let [lower-case-term (str/lower-case term)]
+    (cond
+      (or (= lower-case-term "email")
+          (= lower-case-term "email address"))
+      :email
+
+      (or (= lower-case-term "name")
+          (= lower-case-term "first name"))
+      :first-name
+
+      (= lower-case-term "last name")
+      :last-name
+
+      :else
+      :unknown)))
+
+(defn normalize-header [header]
+  (mapv normalize-header-term header))
+
+(defn valid-csv-header? [header]
+  (let [normalized (normalize-header header)]
+    (or (= normalized [:first-name :last-name :email])
+        (= normalized [:first-name :email])
+        (= normalized [:name :email]))
+    ))
+
+(defn parse-csv [input-stream]
+  (with-open [reader (io/reader input-stream)]
+    (let [rows (doall (csv/read-csv reader))
+          header (first rows)
+          body (rest rows)
+          normalized-header (normalize-header header)]
+      (when-not (valid-csv-header? header)
+        (throw (ex-info "Invalid CSV header" {:header header})))
+      {:normalized-header normalized-header
+       :rows body})))
+
+(defn process-rows [{:keys [normalized-header rows]}]
+  (case normalized-header
+    [:first-name :last-name :email]
+    (mapv (fn [[first last email]]
+            {:name (str first " " last)
+             :email email})
+          rows)
+
+    [:first-name :email]
+    (mapv (fn [[name email]]
+            {:name name
+             :email email})
+          rows)))
+
+(defn upload-handler [file]
+  (when (nil? file)
+    {:error "Missing file upload"})
+
+  (when (not (contains? allowed-content-types (:content-type file)))
+    {:error "Invalid content type"})
+
+  (try
+    (let [parsed (parse-csv (:tempfile file))
+          results (process-rows parsed)]
+      results)
+    (catch Exception e
+      {:error (.getMessage e)})))

--- a/src/clj/rems/service/cadre/parse_users.clj
+++ b/src/clj/rems/service/cadre/parse_users.clj
@@ -31,8 +31,7 @@
   (let [normalized (normalize-header header)]
     (or (= normalized [:first-name :last-name :email])
         (= normalized [:first-name :email])
-        (= normalized [:name :email]))
-    ))
+        (= normalized [:name :email]))))
 
 (defn parse-csv [input-stream]
   (with-open [reader (io/reader input-stream)]


### PR DESCRIPTION
### Changes

- Added `[POST] /cadre-projects/parse-users` to support parsing of csv data to the frontend
    - Currently, if users have a large number of collaborators (i.e., a training course a large number of students), the project owners must manually input each invitation. Adding support to upload a .csv and populate the project invitations would be useful as most institutions which run training courses can export their enrolled members.